### PR TITLE
feat(monitoring): add uptime checks for /api/health and /verify (#84)

### DIFF
--- a/.github/upptime.yml
+++ b/.github/upptime.yml
@@ -1,0 +1,16 @@
+owner: AnnabelJoe
+repo: solarproof-status   # separate repo for status page (create at github.com/AnnabelJoe/solarproof-status)
+
+sites:
+  - name: API Health
+    url: $APP_URL/api/health
+  - name: Public Verifier
+    url: $APP_URL/verify
+
+status-website:
+  cname: status.solarproof.app   # optional custom domain
+  name: SolarProof Status
+  logoUrl: https://solarproof.vercel.app/favicon.ico
+
+# Upptime retains 30 days of history in the repo via git commits.
+# See https://upptime.js.org for setup instructions.

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,39 @@
+name: Uptime Monitoring
+
+on:
+  schedule:
+    - cron: '* * * * *'   # every minute
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check /api/health
+        id: health
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            "${{ vars.APP_URL }}/api/health")
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          [ "$STATUS" = "200" ] || echo "::warning::health check failed (HTTP $STATUS)"
+
+      - name: Check /verify
+        id: verify
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            "${{ vars.APP_URL }}/verify")
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          [ "$STATUS" = "200" ] || echo "::warning::verify page check failed (HTTP $STATUS)"
+
+      - name: Alert on outage
+        if: steps.health.outputs.status != '200' || steps.verify.outputs.status != '200'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_UPTIME_WEBHOOK }}
+        run: |
+          HEALTH="${{ steps.health.outputs.status }}"
+          VERIFY="${{ steps.verify.outputs.status }}"
+          MSG="🚨 *SolarProof outage detected*\n• \`/api/health\` → HTTP $HEALTH\n• \`/verify\` → HTTP $VERIFY\n• Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          curl -s -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"$MSG\"}"

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', ts: Date.now() })
+}


### PR DESCRIPTION
                                                                                                                                                                                                       
  Closes #84                                                                                                                                              
                                                                                                                                                          
  - Adds GET /api/health liveness endpoint                                                                                                                
  - GitHub Actions cron job pings /api/health and /verify every minute                                                                                    
  - Fires Slack webhook alert within 2 minutes of any outage                                                                                              
  - upptime.yml config for public status page with 30-day history                                                                                         
                                                                                                                                                          
  Required secrets/vars: APP_URL, SLACK_UPTIME_WEBHOOK                                                                                                                                                                                                                                                          