### PR TITLE
feat(backup): daily pg_dump to S3 with 30-day retention and Slack ale…

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,26 @@
+name: Database Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # daily at 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  backup:
+    name: pg_dump → S3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pg_dump
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Run backup
+        env:
+          DATABASE_URL: ${{ secrets.SUPABASE_DB_URL }}
+          S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.BACKUP_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.BACKUP_AWS_REGION }}
+          SLACK_BACKUP_WEBHOOK: ${{ secrets.SLACK_BACKUP_WEBHOOK }}
+        run: bash scripts/backup-db.sh

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,96 @@
+# Database Backup & Restore
+
+Daily `pg_dump` backups of the Supabase Postgres database are uploaded to S3 and retained for 30 days. Backups run at **02:00 UTC** via GitHub Actions.
+
+---
+
+## Setup
+
+### 1. Create an S3 bucket
+
+```bash
+aws s3api create-bucket --bucket solarproof-backups --region us-east-1
+# Enable versioning (optional but recommended)
+aws s3api put-bucket-versioning \
+  --bucket solarproof-backups \
+  --versioning-configuration Status=Enabled
+```
+
+### 2. Create an IAM user with minimal permissions
+
+Attach a policy that allows only `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket` on the backup bucket.
+
+### 3. Add GitHub secrets and variables
+
+| Name | Type | Value |
+|---|---|---|
+| `SUPABASE_DB_URL` | Secret | Supabase direct connection string (`postgresql://...`) |
+| `BACKUP_AWS_ACCESS_KEY_ID` | Secret | IAM access key |
+| `BACKUP_AWS_SECRET_ACCESS_KEY` | Secret | IAM secret key |
+| `BACKUP_S3_BUCKET` | Variable | `solarproof-backups` |
+| `BACKUP_AWS_REGION` | Variable | `us-east-1` |
+| `SLACK_BACKUP_WEBHOOK` | Secret | Slack incoming webhook URL (for failure alerts) |
+
+The Supabase direct connection string is found in the Supabase dashboard under **Project Settings → Database → Connection string → URI** (use the direct connection, not the pooler).
+
+---
+
+## Manual backup
+
+```bash
+export DATABASE_URL="postgresql://..."
+export S3_BUCKET="solarproof-backups"
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_DEFAULT_REGION="us-east-1"
+
+bash scripts/backup-db.sh
+```
+
+---
+
+## Restore procedure
+
+### 1. Download the backup
+
+```bash
+# List available backups
+aws s3 ls s3://solarproof-backups/backups/
+
+# Download a specific backup
+aws s3 cp s3://solarproof-backups/backups/solarproof-backup-<TIMESTAMP>.dump ./restore.dump
+```
+
+### 2. Restore to a target database
+
+```bash
+pg_restore \
+  --format=custom \
+  --no-acl \
+  --no-owner \
+  --clean \
+  --if-exists \
+  -d "$TARGET_DATABASE_URL" \
+  restore.dump
+```
+
+> ⚠️ `--clean --if-exists` drops existing objects before restoring. Run against a staging database first to validate the backup before touching production.
+
+### 3. Verify
+
+```bash
+psql "$TARGET_DATABASE_URL" -c "SELECT COUNT(*) FROM readings;"
+psql "$TARGET_DATABASE_URL" -c "SELECT COUNT(*) FROM certificates;"
+```
+
+---
+
+## Retention
+
+The backup script automatically deletes objects older than 30 days from the `backups/` prefix after each successful upload.
+
+---
+
+## Failure alerts
+
+If the backup fails (pg_dump error or S3 upload error), a Slack message is sent to the webhook configured in `SLACK_BACKUP_WEBHOOK`. The GitHub Actions job also fails visibly in the Actions tab.

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# backup-db.sh — dump Supabase Postgres to S3 with 30-day retention
+# Required env vars: DATABASE_URL, S3_BUCKET, AWS_ACCESS_KEY_ID,
+#                    AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+# Optional:          SLACK_BACKUP_WEBHOOK (for failure alerts)
+set -euo pipefail
+
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+FILENAME="solarproof-backup-${TIMESTAMP}.dump"
+TMPFILE="/tmp/${FILENAME}"
+
+alert() {
+  echo "ERROR: $1" >&2
+  if [[ -n "${SLACK_BACKUP_WEBHOOK:-}" ]]; then
+    curl -s -X POST "$SLACK_BACKUP_WEBHOOK" \
+      -H 'Content-Type: application/json' \
+      -d "{\"text\":\"🚨 *SolarProof DB backup failed*\n${1}\"}"
+  fi
+  exit 1
+}
+
+# Dump
+pg_dump --format=custom --no-acl --no-owner "$DATABASE_URL" -f "$TMPFILE" \
+  || alert "pg_dump failed"
+
+# Upload
+aws s3 cp "$TMPFILE" "s3://${S3_BUCKET}/backups/${FILENAME}" \
+  || alert "S3 upload failed"
+
+# Enforce 30-day retention
+CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)   # GNU / BSD fallback
+
+aws s3api list-objects-v2 \
+  --bucket "$S3_BUCKET" \
+  --prefix "backups/" \
+  --query "Contents[?LastModified<='${CUTOFF}'].Key" \
+  --output text \
+| tr '\t' '\n' \
+| grep -v '^$' \
+| while read -r key; do
+    aws s3 rm "s3://${S3_BUCKET}/${key}"
+    echo "Deleted old backup: ${key}"
+  done
+
+rm -f "$TMPFILE"
+echo "Backup complete: s3://${S3_BUCKET}/backups/${FILENAME}"


### PR DESCRIPTION
                                                                                                                         
  Closes #90                                                                                                                                            
                                                                                                                                                          
  - scripts/backup-db.sh: pg_dump → S3 upload, auto-deletes backups older than 30 days                                                                    
  - GitHub Actions workflow runs daily at 02:00 UTC                                                                                                       
  - Slack webhook alert on backup failure                                                                                                                 
  - docs/BACKUP.md: setup guide, manual backup steps, tested restore procedure                                                                            
                                                                                                                                                          
  Required secrets: SUPABASE_DB_URL, BACKUP_AWS_ACCESS_KEY_ID, BACKUP_AWS_SECRET_ACCESS_KEY                                                               
  Required vars: BACKUP_S3_BUCKET, BACKUP_AWS_REGION                                                                                                      
  Optional secret: SLACK_BACKUP_WEBHOOK