### PR TITLE
feat(contracts): add version tracking and migration support (#70)

### DIFF
--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -18,6 +18,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env,
 };
 
+const VERSION: &str = "1.0.0";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -47,6 +49,7 @@ pub enum DataKey {
     /// reading_hash → AuditAnchor
     Anchor(BytesN<32>),
     TotalAnchors,
+    Version,
 }
 
 // ---------------------------------------------------------------------------
@@ -64,6 +67,20 @@ impl AuditRegistry {
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::TotalAnchors, &0_u32);
+        env.storage().instance().set(&DataKey::Version, &soroban_sdk::String::from_str(&env, VERSION));
+    }
+
+    pub fn get_version(env: Env) -> soroban_sdk::String {
+        env.storage().instance()
+            .get(&DataKey::Version)
+            .unwrap_or_else(|| soroban_sdk::String::from_str(&env, VERSION))
+    }
+
+    /// Migrate state schema to a new version. Admin-only.
+    pub fn migrate(env: Env, new_version: soroban_sdk::String) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Version, &new_version);
     }
 
     /// Anchor a signed meter reading on-chain.
@@ -204,5 +221,11 @@ mod tests {
         let hash = BytesN::from_array(&env, &[9u8; 32]);
         assert!(!client.is_anchored(&hash));
         assert!(client.verify(&hash).is_none());
+    }
+
+    #[test]
+    fn test_version() {
+        let (env, client) = setup();
+        assert_eq!(client.get_version(), soroban_sdk::String::from_str(&env, "1.0.0"));
     }
 }

--- a/apps/contracts/community_governance/src/lib.rs
+++ b/apps/contracts/community_governance/src/lib.rs
@@ -4,6 +4,8 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map, String};
 
+const VERSION: &str = "1.0.0";
+
 #[contracttype]
 #[derive(Clone, PartialEq)]
 pub enum ProposalStatus { Active, Passed, Rejected, Expired }
@@ -22,7 +24,7 @@ pub struct Proposal {
 }
 
 #[contracttype]
-pub enum DataKey { Admin, ProposalCount, Proposals, Quorum, VotingPeriod }
+pub enum DataKey { Admin, ProposalCount, Proposals, Quorum, VotingPeriod, Version }
 
 #[contract]
 pub struct CommunityGovernance;
@@ -38,6 +40,20 @@ impl CommunityGovernance {
         env.storage().instance().set(&DataKey::ProposalCount, &0_u32);
         let proposals: Map<u32, Proposal> = Map::new(&env);
         env.storage().instance().set(&DataKey::Proposals, &proposals);
+        env.storage().instance().set(&DataKey::Version, &String::from_str(&env, VERSION));
+    }
+
+    pub fn get_version(env: Env) -> String {
+        env.storage().instance()
+            .get(&DataKey::Version)
+            .unwrap_or_else(|| String::from_str(&env, VERSION))
+    }
+
+    /// Migrate state schema to a new version. Admin-only.
+    pub fn migrate(env: Env, new_version: String) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Version, &new_version);
     }
 
     pub fn propose(env: Env, proposer: Address, title: String, description: String) -> u32 {
@@ -123,5 +139,11 @@ mod tests {
         env.ledger().with_mut(|l| l.sequence_number += 101);
         client.finalize(&id);
         assert_eq!(client.get_proposal(&id).unwrap().status, ProposalStatus::Passed);
+    }
+
+    #[test]
+    fn test_version() {
+        let (env, client) = setup();
+        assert_eq!(client.get_version(), String::from_str(&env, "1.0.0"));
     }
 }

--- a/apps/contracts/energy_token/src/lib.rs
+++ b/apps/contracts/energy_token/src/lib.rs
@@ -8,12 +8,15 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
 
+const VERSION: &str = "1.0.0";
+
 #[contracttype]
 pub enum DataKey {
     Admin,
     Minter,
     TotalMinted,
     TotalBurned,
+    Version,
 }
 
 #[contract]
@@ -29,6 +32,21 @@ impl EnergyToken {
         env.storage().instance().set(&DataKey::Minter, &minter);
         env.storage().instance().set(&DataKey::TotalMinted, &0_i128);
         env.storage().instance().set(&DataKey::TotalBurned, &0_i128);
+        env.storage().instance().set(&DataKey::Version, &String::from_str(&env, VERSION));
+    }
+
+    pub fn get_version(env: Env) -> String {
+        env.storage().instance()
+            .get(&DataKey::Version)
+            .unwrap_or_else(|| String::from_str(&env, VERSION))
+    }
+
+    /// Migrate state schema to a new version. Admin-only.
+    /// Extend this function when the state schema changes between versions.
+    pub fn migrate(env: Env, new_version: String) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Version, &new_version);
     }
 
     pub fn name(env: Env) -> String { String::from_str(&env, "SolarProof Energy Certificate") }
@@ -145,6 +163,12 @@ mod tests {
         let (env, client) = setup();
         assert_eq!(client.symbol(), String::from_str(&env, "SPEC"));
         assert_eq!(client.decimals(), 7);
+    }
+
+    #[test]
+    fn test_version() {
+        let (_, client) = setup();
+        assert_eq!(client.get_version(), String::from_str(&soroban_sdk::Env::default(), "1.0.0"));
     }
 
     #[test]


### PR DESCRIPTION
                                                                                                                              
  ## Summary                                                                                                                                              
  All three contracts now store and expose their deployed version.                                                                                        
                                                                                                                                                          
  - `VERSION` constant set to `"1.0.0"` in each contract                                                                                                  
  - `get_version()` returns the semver string from contract state                                                                                         
  - `migrate(new_version)` is an admin-only function for state schema upgrades                                                                            
  - Version written to instance storage on `initialize()`                                                                                                 
  - Unit tests added for `get_version()` in each contract                                                                                                 
                                                                                                                                                          
  Closes #70                                                                                                                                             
 