### PR TITLE
feat: configure Vercel preview deployments for every PR (#78)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,38 @@
+name: Vercel Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          url=$(vercel deploy --token "$VERCEL_TOKEN" --yes 2>&1 | tail -1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### 🔍 Vercel Preview Deployment\n\n**URL:** ${url}\n\n> Uses Stellar **testnet** contract addresses.`,
+            });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "pnpm build --filter=web",
+  "outputDirectory": "apps/web/.next",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "env": {
+    "NEXT_PUBLIC_STELLAR_NETWORK": "testnet"
+  }
+}


### PR DESCRIPTION
                                                                                                                                                   
  ## Summary                                                                                                                                              
  Enables automatic Vercel preview deployments on every PR with the URL posted as a comment.                                                              
                                                                                                                                                          
  ## Changes                                                                                                                                              
  - `vercel.json` — monorepo build config, forces testnet contract addresses                                                                              
  - `.github/workflows/preview.yml` — deploys preview on PR open/sync and comments the URL                                                                
                                                                                                                                                          
  ## Setup required                                                                                                                                       
  Add these secrets to the repo: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.                                                                    
                                                                                                                                                          
  Closes #78                                                                                                                                              