### PR TITLE
feat: add Docker Compose setup for local development (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ stellar contract build
 cargo test
 ```
 
+### Docker (recommended for local development)
+
+Spin up the full stack — Next.js, Supabase, and Redis — with a single command:
+
+```bash
+cp apps/web/.env.example .env.local   # fill in your values
+docker compose up
+```
+
+The web app will be available at http://localhost:3000.
+
+Data is persisted in named Docker volumes (`supabase_data`, `redis_data`) so it survives container restarts.
+
+To stop and remove containers (volumes are kept):
+
+```bash
+docker compose down
+```
+
 ### Simulate a meter reading
 
 ```bash

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/stellar/package.json ./packages/stellar/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build --filter=web
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/apps/web/.next ./apps/web/.next
+COPY --from=builder /app/apps/web/public ./apps/web/public
+COPY --from=builder /app/apps/web/package.json ./apps/web/
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+EXPOSE 3000
+CMD ["pnpm", "--filter=web", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+      - NEXT_PUBLIC_STELLAR_NETWORK=testnet
+    env_file:
+      - .env.local
+    depends_on:
+      - supabase-db
+      - redis
+    volumes:
+      - ./apps/web:/app/apps/web
+      - /app/apps/web/node_modules
+      - /app/node_modules
+
+  supabase-db:
+    image: supabase/postgres:15.1.0.147
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: solarproof
+    volumes:
+      - supabase_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  supabase_data:
+  redis_data:


### PR DESCRIPTION
                                                                                                                                                     
  ## Summary                                                                                                                                              
  Adds a single-command local dev environment using Docker Compose.                                                                                       
                                                                                                                                                          
  ## Changes                                                                                                                                              
  - `docker-compose.yml` — starts Next.js, Supabase (Postgres), and Redis                                                                                 
  - `apps/web/Dockerfile` — multi-stage build for the Next.js app                                                                                         
  - `README.md` — added Docker setup instructions                                                                                                         
                                                                                                                                                          
  ## How to test                                                                                                                                          
  cp apps/web/.env.example .env.local                                                                                                                     
  docker compose up                                                                                                                                       
                                                                                                                                                          
  App available at http://localhost:3000. Data persists across restarts via named volumes.                                                                
                                                                                                                                                          
  Closes #82                                                                                                                                               
  