### PR TITLE
feat: implement token transfer pause mechanism (#66)

### DIFF
--- a/apps/contracts/energy_token/src/lib.rs
+++ b/apps/contracts/energy_token/src/lib.rs
@@ -14,6 +14,7 @@ pub enum DataKey {
     Minter,
     TotalMinted,
     TotalBurned,
+    Paused,
 }
 
 #[contract]
@@ -29,16 +30,47 @@ impl EnergyToken {
         env.storage().instance().set(&DataKey::Minter, &minter);
         env.storage().instance().set(&DataKey::TotalMinted, &0_i128);
         env.storage().instance().set(&DataKey::TotalBurned, &0_i128);
+        env.storage().instance().set(&DataKey::Paused, &false);
     }
 
     pub fn name(env: Env) -> String { String::from_str(&env, "SolarProof Energy Certificate") }
     pub fn symbol(env: Env) -> String { String::from_str(&env, "SPEC") }
     pub fn decimals(_env: Env) -> u32 { 7 }
 
+    // ── Pause / Unpause ──────────────────────────────────────────────────────
+
+    pub fn pause(env: Env, reason: String) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((symbol_short!("pause"),), (admin, reason));
+    }
+
+    pub fn unpause(env: Env) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((symbol_short!("unpause"),), (admin,));
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    // ── Internal helper ──────────────────────────────────────────────────────
+
+    fn require_not_paused(env: &Env) {
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+        assert!(!paused, "contract is paused");
+    }
+
+    // ── Token operations ─────────────────────────────────────────────────────
+
     pub fn mint(env: Env, to: Address, amount: i128) {
         let minter: Address = env.storage().instance().get(&DataKey::Minter).expect("not initialized");
         minter.require_auth();
         assert!(amount > 0, "amount must be positive");
+        Self::require_not_paused(&env);
 
         let key = (symbol_short!("balance"), to.clone());
         let bal: i128 = env.storage().persistent().get(&key).unwrap_or(0);
@@ -53,6 +85,7 @@ impl EnergyToken {
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
+        Self::require_not_paused(&env);
 
         let key = (symbol_short!("balance"), from.clone());
         let bal: i128 = env.storage().persistent().get(&key).expect("no balance");
@@ -68,6 +101,7 @@ impl EnergyToken {
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
+        Self::require_not_paused(&env);
 
         let fk = (symbol_short!("balance"), from.clone());
         let fb: i128 = env.storage().persistent().get(&fk).expect("no balance");
@@ -107,7 +141,7 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
-    fn setup() -> (Env, EnergyTokenClient<'static>) {
+    fn setup() -> (Env, Address, EnergyTokenClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
         let id = env.register(EnergyToken, ());
@@ -115,12 +149,12 @@ mod tests {
         let admin = Address::generate(&env);
         let minter = Address::generate(&env);
         client.initialize(&admin, &minter);
-        (env, client)
+        (env, admin, client)
     }
 
     #[test]
     fn test_mint_burn_supply() {
-        let (env, client) = setup();
+        let (env, _, client) = setup();
         let user = Address::generate(&env);
         client.mint(&user, &1000_i128);
         assert_eq!(client.total_supply(), 1000_i128);
@@ -131,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_transfer() {
-        let (env, client) = setup();
+        let (env, _, client) = setup();
         let a = Address::generate(&env);
         let b = Address::generate(&env);
         client.mint(&a, &500_i128);
@@ -142,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_metadata() {
-        let (env, client) = setup();
+        let (env, _, client) = setup();
         assert_eq!(client.symbol(), String::from_str(&env, "SPEC"));
         assert_eq!(client.decimals(), 7);
     }
@@ -150,9 +184,63 @@ mod tests {
     #[test]
     #[should_panic(expected = "insufficient balance")]
     fn test_burn_overdraft() {
-        let (env, client) = setup();
+        let (env, _, client) = setup();
         let user = Address::generate(&env);
         client.mint(&user, &10_i128);
         client.burn(&user, &100_i128);
+    }
+
+    // ── Pause tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_pause_unpause() {
+        let (env, _, client) = setup();
+        assert!(!client.is_paused());
+        client.pause(&String::from_str(&env, "emergency"));
+        assert!(client.is_paused());
+        client.unpause();
+        assert!(!client.is_paused());
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_transfer_reverts_when_paused() {
+        let (env, _, client) = setup();
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        client.mint(&a, &500_i128);
+        client.pause(&String::from_str(&env, "compromised meter"));
+        client.transfer(&a, &b, &100_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_mint_reverts_when_paused() {
+        let (env, _, client) = setup();
+        let user = Address::generate(&env);
+        client.pause(&String::from_str(&env, "emergency"));
+        client.mint(&user, &100_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_burn_reverts_when_paused() {
+        let (env, _, client) = setup();
+        let user = Address::generate(&env);
+        client.mint(&user, &100_i128);
+        client.pause(&String::from_str(&env, "emergency"));
+        client.burn(&user, &50_i128);
+    }
+
+    #[test]
+    fn test_operations_resume_after_unpause() {
+        let (env, _, client) = setup();
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        client.mint(&a, &500_i128);
+        client.pause(&String::from_str(&env, "emergency"));
+        client.unpause();
+        client.transfer(&a, &b, &200_i128);
+        assert_eq!(client.balance(&b), 200_i128);
     }
 }


### PR DESCRIPTION
                                                                                                                               
  ## Summary                                                                                                                                              
  Adds admin-controlled pause/unpause to the energy_token contract to stop all token operations during an emergency (e.g. compromised meter).             
                                                                                                                                                          
  ## Changes                                                                                                                                              
  - `pause(reason)` / `unpause()` — admin-only, revert if called by anyone else                                                                           
  - All `mint`, `burn`, and `transfer` calls revert with "contract is paused" when active                                                                 
  - Pause/unpause events emitted with admin address and reason string                                                                                     
  - 5 new tests covering the full lifecycle                                                                                                               
                                                                                                                                                          
  ## Tests added                                                                                                                                          
  - pause/unpause state transitions                                                                                                                       
  - mint, burn, transfer each revert when paused                                                                                                          
  - operations resume correctly after unpause                                                                                                             
                                                                                                                                                          
  Closes #66                                                                                                                                                