### PR TITLE
feat: add automated CodeQL security scanning (#88)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL Security Scan
+
+on:
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 3 * * 1"   # weekly on Monday at 03:00 UTC
+  push:
+    branches: [main]
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, rust]
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: manual
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      # Rust requires an explicit build so CodeQL can trace it
+      - name: Install Rust toolchain
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build Rust contracts
+        if: matrix.language == 'rust'
+        run: cargo build --manifest-path apps/contracts/Cargo.toml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: ${{ matrix.language }}


### PR DESCRIPTION
                                                                                                                                                
  ## Summary                                                                                                                                              
  Adds CodeQL static analysis for JavaScript/TypeScript and Rust on every PR and on a weekly schedule.                                                    
                                                                                                                                                          
  ## Changes                                                                                                                                              
  - `.github/workflows/codeql.yml` — matrix scan for both languages, runs on PR and weekly (Monday 03:00 UTC)                                             
                                                                                                                                                          
  ## Behaviour                                                                                                                                            
  - Uses `security-and-quality` query suite (covers high/critical findings)                                                                               
  - Rust contracts built with `dtolnay/rust-toolchain` for accurate tracing                                                                               
  - Results appear in the GitHub Security tab                                                                                                             
                                                                                                                                                          
  Closes #88               