### PR TITLE
docs(contracts): add interface and error code documentation for all three contracts

### DIFF
--- a/docs/contracts/audit_registry.md
+++ b/docs/contracts/audit_registry.md
@@ -1,0 +1,116 @@
+# audit_registry
+
+Immutable on-chain anchor of Ed25519-signed meter readings.
+
+Once a reading is anchored it **cannot be overwritten**. The anchor serves as cryptographic proof that a physical meter generated the energy before `energy_token` mints a certificate.
+
+- **SDK:** Soroban SDK 23.1.0 / OpenZeppelin Stellar v0.5.1
+
+---
+
+## Flow
+
+```
+1. Meter computes: reading_hash = sha256(meter_id || kwh_stroops || timestamp)
+2. Meter signs reading_hash with its Ed25519 private key
+3. API calls anchor(reading_hash, meter_pubkey, signature, kwh_stroops, meter_id, timestamp)
+4. Contract verifies Ed25519 signature on-chain, then stores AuditAnchor permanently
+5. energy_token.mint() references the anchor as proof of physical generation
+```
+
+---
+
+## Types
+
+### `AuditAnchor`
+
+| Field | Type | Description |
+|---|---|---|
+| `reading_hash` | `BytesN<32>` | SHA-256 of `(meter_id \|\| kwh_stroops \|\| timestamp)` |
+| `meter_pubkey` | `BytesN<32>` | Ed25519 public key of the meter device |
+| `signature` | `BytesN<64>` | Ed25519 signature over `reading_hash` |
+| `kwh_stroops` | `i128` | Energy in stroops (`kwh × 10^7`) |
+| `meter_id` | `String` | Meter device identifier |
+| `timestamp` | `u64` | Unix timestamp of the reading |
+| `anchored_at_ledger` | `u32` | Stellar ledger sequence at anchor time |
+
+---
+
+## Functions
+
+### `initialize(env, admin)`
+
+One-time setup. Panics if called again.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `admin` | `Address` | Contract admin |
+
+---
+
+### `anchor(env, reading_hash, meter_pubkey, signature, kwh_stroops, meter_id, timestamp)`
+
+Verifies the Ed25519 signature and stores the anchor permanently.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `reading_hash` | `BytesN<32>` | SHA-256 hash of the meter reading |
+| `meter_pubkey` | `BytesN<32>` | Ed25519 public key of the meter |
+| `signature` | `BytesN<64>` | Ed25519 signature over `reading_hash` |
+| `kwh_stroops` | `i128` | Energy generated (must be > 0) |
+| `meter_id` | `String` | Meter device identifier |
+| `timestamp` | `u64` | Unix timestamp of the reading |
+
+Returns: nothing  
+Emits event: `("anchor", reading_hash)`
+
+**Example:**
+```bash
+stellar contract invoke --id <CONTRACT_ID> -- anchor \
+  --reading_hash <32-byte-hex> \
+  --meter_pubkey <32-byte-hex> \
+  --signature <64-byte-hex> \
+  --kwh_stroops 125000000 \
+  --meter_id "METER-001" \
+  --timestamp 1700000000
+```
+
+---
+
+### `verify(env, reading_hash) → Option<AuditAnchor>`
+
+Returns the full `AuditAnchor` for the given hash, or `None` if not anchored.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `reading_hash` | `BytesN<32>` | Hash to look up |
+
+---
+
+### `is_anchored(env, reading_hash) → bool`
+
+Returns `true` if the reading hash has been anchored.
+
+---
+
+### `total_anchors(env) → u32`
+
+Returns the total number of anchored readings.
+
+---
+
+### `admin(env) → Address`
+
+Returns the admin address.
+
+---
+
+## Error Codes
+
+| Panic message | Cause |
+|---|---|
+| `"already initialized"` | `initialize` called more than once |
+| `"not initialized"` | Contract called before `initialize` |
+| `"reading already anchored"` | `anchor` called with a `reading_hash` that already exists |
+| `"kwh must be positive"` | `kwh_stroops ≤ 0` |
+| Ed25519 verification failure | Invalid signature — Soroban host panics with a crypto error |

--- a/docs/contracts/community_governance.md
+++ b/docs/contracts/community_governance.md
@@ -1,0 +1,120 @@
+# community_governance
+
+Cooperative on-chain governance — token holders submit proposals and vote. A proposal passes when `yes_votes / total_votes ≥ quorum%` after the voting period ends.
+
+- **SDK:** Soroban SDK 23.1.0 / OpenZeppelin Stellar v0.5.1
+
+---
+
+## Types
+
+### `Proposal`
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `u32` | Auto-incremented proposal ID |
+| `proposer` | `Address` | Address that submitted the proposal |
+| `title` | `String` | Short title |
+| `description` | `String` | Full proposal description |
+| `yes_votes` | `u32` | Count of approve votes |
+| `no_votes` | `u32` | Count of reject votes |
+| `end_ledger` | `u32` | Ledger sequence after which voting closes |
+| `status` | `ProposalStatus` | Current status |
+
+### `ProposalStatus`
+
+| Variant | Description |
+|---|---|
+| `Active` | Voting is open |
+| `Passed` | Yes votes met quorum after period ended |
+| `Rejected` | Yes votes did not meet quorum |
+| `Expired` | No votes were cast before period ended |
+
+---
+
+## Functions
+
+### `initialize(env, admin, quorum, voting_period_ledgers)`
+
+One-time setup. Panics if called again.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `admin` | `Address` | Contract admin |
+| `quorum` | `u32` | Minimum yes-vote percentage to pass (1–100) |
+| `voting_period_ledgers` | `u32` | Number of ledgers a proposal stays open |
+
+---
+
+### `propose(env, proposer, title, description) → u32`
+
+Creates a new proposal. Requires `proposer` auth.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `proposer` | `Address` | Proposal author |
+| `title` | `String` | Short title |
+| `description` | `String` | Full description |
+
+Returns: new proposal ID (`u32`)
+
+**Example:**
+```bash
+stellar contract invoke --id <CONTRACT_ID> -- propose \
+  --proposer GABC...XYZ \
+  --title "Add batch anchor support" \
+  --description "Allow anchoring multiple readings in one transaction"
+```
+
+---
+
+### `vote(env, voter, proposal_id, approve)`
+
+Casts a vote. Requires `voter` auth. Each address may vote once per proposal.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `voter` | `Address` | Voter address |
+| `proposal_id` | `u32` | Target proposal |
+| `approve` | `bool` | `true` = yes, `false` = no |
+
+---
+
+### `finalize(env, proposal_id)`
+
+Resolves a proposal after its voting period ends. Anyone can call this.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `proposal_id` | `u32` | Proposal to finalize |
+
+Sets status to `Passed`, `Rejected`, or `Expired`.  
+Emits event: `("final", (proposal_id, status))`
+
+---
+
+### `get_proposal(env, proposal_id) → Option<Proposal>`
+
+Returns the full `Proposal` struct, or `None` if the ID doesn't exist.
+
+---
+
+### `proposal_count(env) → u32`
+
+Returns the total number of proposals created.
+
+---
+
+## Error Codes
+
+| Panic message | Cause |
+|---|---|
+| `"already initialized"` | `initialize` called more than once |
+| `"not initialized"` | Contract called before `initialize` |
+| `"quorum must be 1-100"` | `quorum` out of valid range |
+| `"already voted"` | Voter has already cast a vote on this proposal |
+| `"proposal not found"` | `proposal_id` does not exist |
+| `"proposal not active"` | Voting or finalization attempted on a non-`Active` proposal |
+| `"voting period ended"` | `vote` called after `end_ledger` |
+| `"already finalized"` | `finalize` called on a non-`Active` proposal |
+| `"voting still open"` | `finalize` called before `end_ledger` has passed |

--- a/docs/contracts/energy_token.md
+++ b/docs/contracts/energy_token.md
@@ -1,0 +1,119 @@
+# energy_token
+
+SEP-41 fungible certificate token. **1 token = 1 kWh** of verified renewable energy.
+
+Minting requires a valid audit anchor in `audit_registry` for the same reading hash.
+
+- **Symbol:** `SPEC`
+- **Decimals:** `7` (amounts in stroops: 1 kWh = `10_000_000`)
+- **SDK:** Soroban SDK 23.1.0 / OpenZeppelin Stellar v0.5.1
+
+---
+
+## Functions
+
+### `initialize(env, admin, minter)`
+
+One-time setup. Panics if called again.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `admin` | `Address` | Account authorized to call `set_minter` |
+| `minter` | `Address` | Account authorized to call `mint` |
+
+---
+
+### `mint(env, to, amount)`
+
+Mints `amount` tokens to `to`. Requires `minter` auth.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `to` | `Address` | Recipient address |
+| `amount` | `i128` | Amount in stroops (must be > 0) |
+
+Emits event: `("mint", (to, amount))`
+
+**Example:**
+```bash
+stellar contract invoke --id <CONTRACT_ID> -- mint \
+  --to GABC...XYZ \
+  --amount 10000000
+```
+
+---
+
+### `burn(env, from, amount)`
+
+Burns `amount` tokens from `from`. Requires `from` auth.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `from` | `Address` | Token holder |
+| `amount` | `i128` | Amount in stroops (must be > 0, ≤ balance) |
+
+Emits event: `("burn", (from, amount))`
+
+---
+
+### `transfer(env, from, to, amount)`
+
+Transfers `amount` from `from` to `to`. Requires `from` auth.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `from` | `Address` | Sender |
+| `to` | `Address` | Recipient |
+| `amount` | `i128` | Amount in stroops (must be > 0, ≤ balance) |
+
+Emits event: `("transfer", (from, to, amount))`
+
+---
+
+### `balance(env, account) → i128`
+
+Returns the token balance of `account` in stroops.
+
+---
+
+### `total_supply(env) → i128`
+
+Returns `total_minted - total_burned`.
+
+---
+
+### `set_minter(env, new_minter)`
+
+Replaces the authorized minter. Requires `admin` auth.
+
+---
+
+### `admin(env) → Address`
+
+Returns the admin address.
+
+---
+
+### `name(env) → String`
+
+Returns `"SolarProof Energy Certificate"`.
+
+### `symbol(env) → String`
+
+Returns `"SPEC"`.
+
+### `decimals(env) → u32`
+
+Returns `7`.
+
+---
+
+## Error Codes
+
+| Panic message | Cause |
+|---|---|
+| `"already initialized"` | `initialize` called more than once |
+| `"amount must be positive"` | `amount ≤ 0` passed to `mint`, `burn`, or `transfer` |
+| `"no balance"` | `burn` called on account with no balance entry |
+| `"insufficient balance"` | `burn` or `transfer` amount exceeds balance |
+| `"not initialized"` | Contract called before `initialize` |


### PR DESCRIPTION
## Summary

Adds `docs/contracts/` with a dedicated markdown file per contract, satisfying all acceptance criteria for #98.

## Files added
- `docs/contracts/energy_token.md` — SEP-41 token: all functions, params, return values, error codes, example invocations
- `docs/contracts/audit_registry.md` — Ed25519 anchor registry: flow diagram, AuditAnchor type, all functions, error codes, example invocation
- `docs/contracts/community_governance.md` — Proposals + voting: Proposal/ProposalStatus types, all functions, error codes, example invocation

Closes #98