### PR TITLE
chore(ci): configure Turborepo remote caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
         working-directory: apps/web
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - run: pnpm type-check
         working-directory: apps/web
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - run: pnpm build
         working-directory: apps/web
         env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
           NEXT_PUBLIC_STELLAR_NETWORK: testnet

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "remoteCache": {
+    "enabled": true,
+    "signature": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Enables Turborepo remote caching via Vercel Remote Cache, satisfying the acceptance criteria for #87.

## Changes

### `turbo.json`
- Added `remoteCache.enabled: true` — activates remote cache for all tasks
- Added `remoteCache.signature: true` — verifies cache artifact signatures to prevent poisoning

### `.github/workflows/ci.yml`
- Passes `TURBO_TOKEN` and `TURBO_TEAM` secrets to lint, type-check, and build steps

## Setup required
Add two repository secrets (Settings → Secrets → Actions):
- `TURBO_TOKEN` — from [vercel.com/account/tokens](https://vercel.com/account/tokens)
- `TURBO_TEAM` — your Vercel team slug (e.g. `my-team`)

Cache is automatically invalidated when `package.json`, lockfiles, or source inputs change (Turborepo default hashing).

Closes #87