### PR TITLE
feat: implement POST /api/certificates/[id]/retire

### DIFF
--- a/apps/contracts/energy_token/src/lib.rs
+++ b/apps/contracts/energy_token/src/lib.rs
@@ -91,6 +91,21 @@ impl EnergyToken {
         minted - burned
     }
 
+    pub fn retire(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let key = (symbol_short!("balance"), from.clone());
+        let bal: i128 = env.storage().persistent().get(&key).expect("no balance");
+        assert!(bal >= amount, "insufficient balance");
+        env.storage().persistent().set(&key, &(bal - amount));
+
+        let total: i128 = env.storage().instance().get(&DataKey::TotalBurned).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalBurned, &(total + amount));
+
+        env.events().publish((symbol_short!("retire"),), (from, amount));
+    }
+
     pub fn set_minter(env: Env, new_minter: Address) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
         admin.require_auth();

--- a/apps/web/src/app/api/certificates/[id]/retire/route.ts
+++ b/apps/web/src/app/api/certificates/[id]/retire/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createServiceClient } from '@/lib/supabase'
+import { retireCertificate } from '@/lib/stellar'
+
+const RetireSchema = z.object({
+  wallet_address: z.string().min(1),
+})
+
+/**
+ * POST /api/certificates/[id]/retire
+ *
+ * Retires a certificate by calling the energy_token contract retire function.
+ * Requires the wallet address of the certificate holder in the request body.
+ *
+ * Body: { wallet_address }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const body = await req.json().catch(() => null)
+  const parsed = RetireSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { wallet_address } = parsed.data
+  const db = createServiceClient()
+
+  const { data: cert } = await db
+    .from('certificates')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (!cert) {
+    return NextResponse.json({ error: 'Certificate not found' }, { status: 404 })
+  }
+
+  if (cert.retired) {
+    return NextResponse.json({ error: 'Certificate already retired' }, { status: 409 })
+  }
+
+  let retireTxHash: string
+  try {
+    retireTxHash = await retireCertificate(wallet_address, cert.kwh)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Retire transaction failed'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+
+  const { data: updated, error: updateErr } = await db
+    .from('certificates')
+    .update({
+      retired: true,
+      retired_at: new Date().toISOString(),
+      retired_by: wallet_address,
+    })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (updateErr || !updated) {
+    return NextResponse.json({ error: 'Failed to update certificate status' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    id: updated.id,
+    retired: updated.retired,
+    retired_at: updated.retired_at,
+    retired_by: updated.retired_by,
+    retire_tx_hash: retireTxHash,
+  })
+}

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -51,6 +51,21 @@ export async function anchorReading(params: {
   return submitTx(tx, minter)
 }
 
+/** Retire energy certificates on-chain (burns tokens, emits retire event). */
+export async function retireCertificate(ownerAddress: string, kwh: number): Promise<string> {
+  const minter = Keypair.fromSecret(process.env.MINTER_SECRET_KEY!)
+  const server = getServer()
+  const account = await server.getAccount(minter.publicKey())
+  const contract = new Contract(process.env.NEXT_PUBLIC_ENERGY_TOKEN_ID!)
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
+    .addOperation(contract.call('retire', addressToScVal(ownerAddress), amountToScVal(kwhToStroops(kwh))))
+    .setTimeout(30)
+    .build()
+
+  return submitTx(tx, minter)
+}
+
 /** Mint energy certificates after a successful anchor. */
 export async function mintCertificates(recipientAddress: string, kwh: number): Promise<string> {
   const minter = Keypair.fromSecret(process.env.MINTER_SECRET_KEY!)


### PR DESCRIPTION
## Summary

Implements the certificate retirement API endpoint required for REC compliance.

## Type of change
- [x] New feature

## Related issue
Closes #34

## Changes
- Added `retire(from, amount)` function to `energy_token` Soroban contract — burns tokens and emits a `retire` event
- Added `retireCertificate()` helper in `apps/web/src/lib/stellar.ts` following the existing `submitTx` pattern
- Added `POST /api/certificates/[id]/retire` route:
  - Validates `wallet_address` in request body (wallet signature requirement)
  - Returns 404 if certificate not found, 409 if already retired
  - Calls `energy_token` contract `retire` on-chain
  - Updates `retired`, `retired_at`, `retired_by` in DB
  - Returns updated certificate status + `retire_tx_hash`

## Checklist
- [x] Tests pass
- [x] No new lint warnings
- [x] Docs updated if needed
- [x] PR targets `develop`