### PR TITLE
chore: set up Dependabot for npm and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # npm — monorepo root + all workspaces
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types: [patch]
+      minor-updates:
+        update-types: [minor]
+    labels:
+      - dependencies
+      - javascript
+    ignore:
+      # Flag major version bumps for manual review
+      - dependency-name: "*"
+        update-types: [version-update:semver-major]
+
+  # Cargo — contracts workspace
+  - package-ecosystem: cargo
+    directory: /apps/contracts
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types: [patch]
+      minor-updates:
+        update-types: [minor]
+    labels:
+      - dependencies
+      - rust
+    ignore:
+      # Flag major version bumps for manual review
+      - dependency-name: "*"
+        update-types: [version-update:semver-major]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-merge patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Configures Dependabot to automatically open weekly dependency update PRs for both npm and Cargo, with auto-merge for passing patch updates.

## Type of change
- [x] CI / tooling

## Related issue
Closes #80

## Changes
- `.github/dependabot.yml`:
  - `npm` ecosystem at repo root — covers all pnpm workspaces
  - `cargo` ecosystem at `/apps/contracts`
  - Weekly schedule (Mondays), patch and minor updates grouped separately
  - Major version updates ignored via `ignore` rules — flagged for manual review
- `.github/workflows/dependabot-auto-merge.yml`:
  - Triggers on every PR from `dependabot[bot]`
  - Uses `dependabot/fetch-metadata` to detect update type
  - Auto-squash-merges patch-only PRs after CI passes

## Checklist
- [x] Tests pass
- [x] No new lint warnings
- [x] Docs updated if needed
- [x] PR targets `develop`