### PR TITLE
feat: pin Rust toolchain and harden CI for Soroban contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain (pinned via rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.85.0"
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2

--- a/apps/contracts/rust-toolchain.toml
+++ b/apps/contracts/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Closes #77

## Changes

- Add `apps/contracts/rust-toolchain.toml` pinned to Rust **1.85.0** with `wasm32-unknown-unknown` target and `rustfmt`/`clippy` components
- Update CI `contracts` job to use `dtolnay/rust-toolchain@master` with the pinned version
- `cargo clippy` runs with `-D warnings` (fails on any warning)
- `Swatinem/rust-cache@v2` handles build caching

## Acceptance Criteria

- [x] CI runs `cargo fmt --check`, `cargo clippy`, `cargo test`
- [x] Rust toolchain version pinned in `rust-toolchain.toml`
- [x] CI fails on any clippy warning (`-D warnings`)
- [x] Build cache configured via `Swatinem/rust-cache@v2`