### PR TITLE
feat: add pnpm audit and cargo audit to CI pipeline

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,86 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  npm-audit:
+    name: pnpm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Run pnpm audit
+        id: npm_audit
+        run: pnpm audit --audit-level=high 2>&1 | tee /tmp/npm-audit.txt; exit ${PIPESTATUS[0]}
+        continue-on-error: true
+      - name: Post audit results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('/tmp/npm-audit.txt', 'utf8');
+            const status = '${{ steps.npm_audit.outcome }}' === 'success' ? '✅' : '❌';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### ${status} pnpm audit\n\`\`\`\n${output.slice(0, 6000)}\n\`\`\``
+            });
+      - name: Fail if audit found high/critical issues
+        if: steps.npm_audit.outcome == 'failure'
+        run: exit 1
+
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.85.0"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/contracts
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo audit
+        id: cargo_audit
+        run: cargo audit 2>&1 | tee /tmp/cargo-audit.txt; exit ${PIPESTATUS[0]}
+        working-directory: apps/contracts
+        continue-on-error: true
+      - name: Post audit results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('/tmp/cargo-audit.txt', 'utf8');
+            const status = '${{ steps.cargo_audit.outcome }}' === 'success' ? '✅' : '❌';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### ${status} cargo audit\n\`\`\`\n${output.slice(0, 6000)}\n\`\`\``
+            });
+      - name: Fail if audit found vulnerabilities
+        if: steps.cargo_audit.outcome == 'failure'
+        run: exit 1

--- a/apps/contracts/audit.toml
+++ b/apps/contracts/audit.toml
@@ -1,0 +1,13 @@
+# cargo audit ignore file
+# Document known false positives here with justification and review date.
+#
+# Format:
+# [advisories.ignore]
+# id = "RUSTSEC-YYYY-NNNN"  # reason — reviewed YYYY-MM-DD
+#
+# Example (uncomment and fill in when needed):
+# [advisories.ignore]
+# id = "RUSTSEC-2023-0001"  # only affects feature X which we don't use — reviewed 2026-04-23
+
+[advisories]
+ignore = []


### PR DESCRIPTION
## Summary

Closes #91

## Changes

- Add `.github/workflows/audit.yml` with two jobs:
  - **pnpm audit** — fails on `high`/`critical` severity (`--audit-level=high`)
  - **cargo audit** — fails on any vulnerability reported by `cargo-audit`
- Both jobs post results as a PR comment via `actions/github-script`
- Workflow runs on push/PR to `main`/`develop` and on a weekly schedule (Monday 06:00 UTC)
- Add `apps/contracts/audit.toml` — ignore file for documenting known false positives with justification and review date

## Acceptance Criteria

- [x] `pnpm audit` runs in CI, fails on high/critical
- [x] `cargo audit` runs in CI, fails on high/critical
- [x] Audit results posted as PR comment
- [x] Known false positives documented in `apps/contracts/audit.toml`