### PR TITLE
fix: secrets management — placeholder .env.example + secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
       - run: pnpm build
         working-directory: apps/web
         env:
-          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder' }}
           NEXT_PUBLIC_STELLAR_NETWORK: testnet
-          NEXT_PUBLIC_ENERGY_TOKEN_ID: placeholder
-          NEXT_PUBLIC_AUDIT_REGISTRY_ID: placeholder
-          NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID: placeholder
+          NEXT_PUBLIC_ENERGY_TOKEN_ID: ${{ secrets.NEXT_PUBLIC_ENERGY_TOKEN_ID || 'placeholder' }}
+          NEXT_PUBLIC_AUDIT_REGISTRY_ID: ${{ secrets.NEXT_PUBLIC_AUDIT_REGISTRY_ID || 'placeholder' }}
+          NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID: ${{ secrets.NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID || 'placeholder' }}
 
   contracts:
     name: Contracts (fmt + clippy + test)

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,19 @@
+name: Secret Scanning
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  gitleaks:
+    name: Detect secrets (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  description = "Allowlist for known safe placeholder values"
+  paths = [
+    "apps/web/.env.example",
+  ]

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,13 +1,17 @@
-# Supabase
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Supabase — copy from your Supabase project settings
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 
-# Stellar / Soroban
+# Stellar / Soroban network
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Deployed contract IDs (set after running deploy-contracts workflow)
 NEXT_PUBLIC_ENERGY_TOKEN_ID=
 NEXT_PUBLIC_AUDIT_REGISTRY_ID=
 NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID=
 
-# Minter keypair (server-side only)
-MINTER_SECRET_KEY=
+# Minter keypair — server-side only, NEVER expose to the client
+# Generate with: stellar keys generate minter
+# Store the secret in GitHub Actions secrets / Vercel env vars
+MINTER_SECRET_KEY=your-minter-secret-key-here


### PR DESCRIPTION
## Summary

Resolves #85

## Changes

- `.env.example` — all values replaced with explicit `your-*-here` placeholders; no real-looking values remain
- `secret-scanning.yml` — new workflow runs gitleaks on every push/PR to `main`/`develop` to block accidental secret commits
- `ci.yml` — build step now reads `NEXT_PUBLIC_*` from GitHub Actions secrets (with safe fallback placeholders) instead of hardcoded strings
- `.gitleaks.toml` — allowlists `.env.example` so placeholder strings don't trigger false positives

## Acceptance Criteria

- [x] All secrets stored in GitHub Actions secrets or Vercel env vars
- [x] No secrets in committed files
- [x] `.env.example` contains only placeholder values
- [x] Secret scanning enabled on repo (gitleaks workflow)
