### PR TITLE
feat: optimize audit_registry storage — hash-only on-chain (>80% reduction)

### DIFF
--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -2,41 +2,34 @@
 //!
 //! Immutable on-chain anchor of Ed25519-signed meter readings.
 //!
+//! ## Storage optimisation (issue #59)
+//! Only the `reading_hash` (32 bytes) and `anchored_at_ledger` (4 bytes) are
+//! stored on-chain.  The full payload (meter_pubkey, signature, kwh_stroops,
+//! meter_id, timestamp) is stored off-chain in Supabase, keyed by
+//! `reading_hash`.  Verification is still possible from the on-chain hash
+//! alone: callers recompute `sha256(meter_id || kwh_stroops_le || timestamp_le)`
+//! and check `is_anchored(hash)`.
+//!
 //! ## Flow
 //! 1. Smart meter signs `sha256(meter_id || kwh || timestamp)` with its Ed25519 key
-//! 2. API calls `anchor(reading_hash, meter_pubkey, signature, kwh, meter_id)`
-//! 3. Contract verifies the signature and stores the anchor permanently
+//! 2. API verifies the signature off-chain, then calls `anchor(reading_hash)`
+//! 3. Contract stores only the hash + ledger sequence permanently
 //! 4. `energy_token.mint()` can reference the anchor as proof of physical generation
-//!
-//! ## Verification
-//! Anyone can call `verify(reading_hash)` to confirm a reading is anchored
-//! and retrieve its full audit record.
 
 #![no_std]
 
-use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, BytesN, Env};
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
+/// Minimal on-chain record — 36 bytes vs ~200+ bytes previously.
 #[contracttype]
 #[derive(Clone)]
 pub struct AuditAnchor {
-    /// SHA-256 of (meter_id || kwh_stroops || timestamp_unix)
+    /// SHA-256 of (meter_id || kwh_stroops_le || timestamp_unix_le)
     pub reading_hash: BytesN<32>,
-    /// Ed25519 public key of the meter device (32 bytes)
-    pub meter_pubkey: BytesN<32>,
-    /// Ed25519 signature over reading_hash (64 bytes)
-    pub signature: BytesN<64>,
-    /// Energy in stroops (kwh * 10^7)
-    pub kwh_stroops: i128,
-    /// Meter device identifier
-    pub meter_id: soroban_sdk::String,
-    /// Unix timestamp of the reading
-    pub timestamp: u64,
     /// Stellar ledger sequence at anchor time
     pub anchored_at_ledger: u32,
 }
@@ -58,7 +51,7 @@ pub struct AuditRegistry;
 
 #[contractimpl]
 impl AuditRegistry {
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: soroban_sdk::Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
@@ -66,41 +59,19 @@ impl AuditRegistry {
         env.storage().instance().set(&DataKey::TotalAnchors, &0_u32);
     }
 
-    /// Anchor a signed meter reading on-chain.
+    /// Anchor a reading hash on-chain.
     ///
-    /// The contract verifies the Ed25519 signature before storing.
-    /// Once anchored, a reading cannot be overwritten.
-    pub fn anchor(
-        env: Env,
-        reading_hash: BytesN<32>,
-        meter_pubkey: BytesN<32>,
-        signature: BytesN<64>,
-        kwh_stroops: i128,
-        meter_id: soroban_sdk::String,
-        timestamp: u64,
-    ) {
-        // Prevent duplicate anchors.
+    /// Signature verification is performed off-chain by the API before calling
+    /// this function.  Only the hash is stored; full payload lives in Supabase.
+    /// Once anchored, a hash cannot be overwritten.
+    pub fn anchor(env: Env, reading_hash: BytesN<32>) {
         let key = DataKey::Anchor(reading_hash.clone());
         if env.storage().persistent().has(&key) {
             panic!("reading already anchored");
         }
 
-        assert!(kwh_stroops > 0, "kwh must be positive");
-
-        // Verify Ed25519 signature: sig over reading_hash bytes.
-        env.crypto().ed25519_verify(
-            &meter_pubkey,
-            &Bytes::from_slice(&env, reading_hash.to_array().as_ref()),
-            &signature,
-        );
-
         let anchor = AuditAnchor {
             reading_hash: reading_hash.clone(),
-            meter_pubkey,
-            signature,
-            kwh_stroops,
-            meter_id,
-            timestamp,
             anchored_at_ledger: env.ledger().sequence(),
         };
 
@@ -112,7 +83,7 @@ impl AuditRegistry {
         env.events().publish((symbol_short!("anchor"),), reading_hash);
     }
 
-    /// Verify a reading is anchored and return its audit record.
+    /// Returns the anchor record if the hash is anchored, otherwise None.
     pub fn verify(env: Env, reading_hash: BytesN<32>) -> Option<AuditAnchor> {
         env.storage().persistent().get(&DataKey::Anchor(reading_hash))
     }
@@ -126,7 +97,7 @@ impl AuditRegistry {
         env.storage().instance().get(&DataKey::TotalAnchors).unwrap_or(0)
     }
 
-    pub fn admin(env: Env) -> Address {
+    pub fn admin(env: Env) -> soroban_sdk::Address {
         env.storage().instance().get(&DataKey::Admin).expect("not initialized")
     }
 }
@@ -138,71 +109,47 @@ impl AuditRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{
-        testutils::{Address as _, ed25519::Sign},
-        Env,
-    };
+    use soroban_sdk::{testutils::Address as _, Env};
 
     fn setup() -> (Env, AuditRegistryClient<'static>) {
         let env = Env::default();
         env.mock_all_auths();
         let id = env.register(AuditRegistry, ());
         let client = AuditRegistryClient::new(&env, &id);
-        let admin = Address::generate(&env);
+        let admin = soroban_sdk::Address::generate(&env);
         client.initialize(&admin);
         (env, client)
     }
 
-    fn make_reading_hash(env: &Env) -> BytesN<32> {
-        // Deterministic test hash
+    fn hash(env: &Env) -> BytesN<32> {
         BytesN::from_array(env, &[1u8; 32])
     }
 
     #[test]
     fn test_anchor_and_verify() {
         let (env, client) = setup();
-
-        // Generate a real Ed25519 keypair via Soroban testutils
-        let signer = soroban_sdk::testutils::ed25519::Signer::generate(&env);
-        let reading_hash = make_reading_hash(&env);
-        let sig = signer.sign(&env, &Bytes::from_slice(&env, reading_hash.to_array().as_ref()));
-
-        client.anchor(
-            &reading_hash,
-            &signer.public_key(&env),
-            &sig,
-            &1_000_000_0_i128,
-            &soroban_sdk::String::from_str(&env, "METER-001"),
-            &1_700_000_000_u64,
-        );
-
-        assert!(client.is_anchored(&reading_hash));
+        let h = hash(&env);
+        client.anchor(&h);
+        assert!(client.is_anchored(&h));
         assert_eq!(client.total_anchors(), 1);
-
-        let anchor = client.verify(&reading_hash).unwrap();
-        assert_eq!(anchor.kwh_stroops, 1_000_000_0_i128);
+        let anchor = client.verify(&h).unwrap();
+        assert_eq!(anchor.reading_hash, h);
     }
 
     #[test]
     #[should_panic(expected = "reading already anchored")]
     fn test_duplicate_anchor_rejected() {
         let (env, client) = setup();
-        let signer = soroban_sdk::testutils::ed25519::Signer::generate(&env);
-        let reading_hash = make_reading_hash(&env);
-        let sig = signer.sign(&env, &Bytes::from_slice(&env, reading_hash.to_array().as_ref()));
-
-        client.anchor(&reading_hash, &signer.public_key(&env), &sig, &100_i128,
-            &soroban_sdk::String::from_str(&env, "METER-001"), &1_700_000_000_u64);
-        // Second call must panic
-        client.anchor(&reading_hash, &signer.public_key(&env), &sig, &100_i128,
-            &soroban_sdk::String::from_str(&env, "METER-001"), &1_700_000_000_u64);
+        let h = hash(&env);
+        client.anchor(&h);
+        client.anchor(&h);
     }
 
     #[test]
     fn test_not_anchored_returns_none() {
         let (env, client) = setup();
-        let hash = BytesN::from_array(&env, &[9u8; 32]);
-        assert!(!client.is_anchored(&hash));
-        assert!(client.verify(&hash).is_none());
+        let h = BytesN::from_array(&env, &[9u8; 32]);
+        assert!(!client.is_anchored(&h));
+        assert!(client.verify(&h).is_none());
     }
 }

--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -77,17 +77,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to save reading' }, { status: 500 })
   }
 
-  // Anchor on-chain
+  // Anchor on-chain (hash only — full payload already in Supabase)
   let anchorTxHash: string
   try {
-    anchorTxHash = await anchorReading({
-      readingHash,
-      meterPubkeyHex: meter.pubkey_hex,
-      signatureHex: signature_hex,
-      kwhStroops,
-      meterId: meter_id,
-      timestampUnix: BigInt(timestamp),
-    })
+    anchorTxHash = await anchorReading({ readingHash })
     await db.from('readings').update({ anchored: true, anchor_tx_hash: anchorTxHash }).eq('id', reading.id)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Anchor failed'

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -1,7 +1,6 @@
 import { Keypair, TransactionBuilder, Networks, BASE_FEE, Contract } from '@stellar/stellar-sdk'
 import { SorobanRpc } from '@stellar/stellar-sdk'
 import { kwhToStroops, amountToScVal, addressToScVal, bytesToScVal } from '@solarproof/stellar'
-import { nativeToScVal } from '@stellar/stellar-sdk'
 
 const NETWORK_PASSPHRASE = Networks.TESTNET
 const RPC_URL = 'https://soroban-testnet.stellar.org'
@@ -21,14 +20,15 @@ async function submitTx(tx: ReturnType<typeof TransactionBuilder.prototype.build
   return result.hash
 }
 
-/** Anchor a signed reading hash in the audit_registry contract. */
+/**
+ * Anchor a reading hash in the audit_registry contract.
+ *
+ * Only the 32-byte hash is stored on-chain (issue #59 optimisation).
+ * The full payload (pubkey, signature, kwh, meter_id, timestamp) is
+ * persisted off-chain in Supabase before this call.
+ */
 export async function anchorReading(params: {
   readingHash: Buffer
-  meterPubkeyHex: string
-  signatureHex: string
-  kwhStroops: bigint
-  meterId: string
-  timestampUnix: bigint
 }): Promise<string> {
   const minter = Keypair.fromSecret(process.env.MINTER_SECRET_KEY!)
   const server = getServer()
@@ -36,15 +36,7 @@ export async function anchorReading(params: {
   const contract = new Contract(process.env.NEXT_PUBLIC_AUDIT_REGISTRY_ID!)
 
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
-    .addOperation(contract.call(
-      'anchor',
-      bytesToScVal(params.readingHash),
-      bytesToScVal(Buffer.from(params.meterPubkeyHex, 'hex')),
-      bytesToScVal(Buffer.from(params.signatureHex, 'hex')),
-      amountToScVal(params.kwhStroops),
-      nativeToScVal(params.meterId, { type: 'string' }),
-      nativeToScVal(params.timestampUnix, { type: 'u64' }),
-    ))
+    .addOperation(contract.call('anchor', bytesToScVal(params.readingHash)))
     .setTimeout(30)
     .build()
 


### PR DESCRIPTION
## Summary

Resolves #59

## Problem

The previous `AuditAnchor` stored the full reading payload on-chain:
`reading_hash` (32B) + `meter_pubkey` (32B) + `signature` (64B) + `kwh_stroops` (16B) + `meter_id` (variable) + `timestamp` (8B) + `anchored_at_ledger` (4B) ≈ **200+ bytes per ledger entry**.

## Solution

Store only what is needed for on-chain verification:

| Field | Size |
|---|---|
| `reading_hash` | 32 bytes |
| `anchored_at_ledger` | 4 bytes |
| **Total** | **36 bytes** |

**~82% storage reduction per anchor.**

The full payload (pubkey, signature, kwh, meter_id, timestamp) is already persisted in the Supabase `readings` table, keyed by `reading_hash`. Verification flow:
1. Caller recomputes `sha256(meter_id || kwh_stroops_le || timestamp_le)`
2. Calls `is_anchored(hash)` on-chain → `true` proves the reading was accepted
3. Full details retrieved from Supabase by hash

## Changes

- `audit_registry/src/lib.rs` — slim `AuditAnchor` struct; `anchor()` takes only `reading_hash`; Ed25519 verification moved entirely off-chain (API already verifies before calling)
- `apps/web/src/lib/stellar.ts` — `anchorReading()` now accepts only `{ readingHash }`
- `apps/web/src/app/api/readings/route.ts` — updated call site

## Acceptance Criteria

- [x] Only SHA-256 hash stored on-chain
- [x] Full payload stored off-chain (Supabase) with hash reference
- [x] Verification still possible from on-chain hash alone
- [x] Storage cost reduced by >80% (36 bytes vs 200+ bytes, ~82%)
