### PR TITLE
feat: Redis/Upstash caching for certificate queries

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,3 +11,7 @@ NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID=
 
 # Minter keypair (server-side only)
 MINTER_SECRET_KEY=
+
+# Upstash Redis (optional — caching layer for certificate queries)
+UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your-token

--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -5,6 +5,7 @@ import { createServiceClient } from '@/lib/supabase'
 import { anchorReading, mintCertificates } from '@/lib/stellar'
 import { computeReadingHash } from '@/lib/crypto'
 import { kwhToStroops } from '@solarproof/stellar'
+import { invalidateCert } from '@/lib/cache'
 
 const ReadingSchema = z.object({
   meter_id: z.string().uuid(),
@@ -112,6 +113,9 @@ export async function POST(req: NextRequest) {
       issued_at: new Date().toISOString(),
       retired: false,
     })
+
+    // Invalidate any stale cache entries for this certificate
+    await invalidateCert(reading.id, readingHash.toString('hex'), mintTxHash)
 
     return NextResponse.json({ reading_id: reading.id, anchor_tx_hash: anchorTxHash, mint_tx_hash: mintTxHash }, { status: 201 })
   } catch (err) {

--- a/apps/web/src/app/api/verify/route.ts
+++ b/apps/web/src/app/api/verify/route.ts
@@ -1,16 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase'
+import { getCachedCert, setCachedCert } from '@/lib/cache'
 
 /**
  * GET /api/verify?id=<certificate_id_or_reading_hash_or_tx_hash>
  *
  * Public endpoint — no auth required.
  * Returns the full chain of custody for a certificate.
+ * Results are cached in Redis for 60 s (TTL defined in cache.ts).
  */
 export async function GET(req: NextRequest) {
   const id = req.nextUrl.searchParams.get('id')?.trim()
   if (!id) {
     return NextResponse.json({ error: 'id parameter required' }, { status: 400 })
+  }
+
+  // Cache lookup
+  const cached = await getCachedCert<unknown>(id)
+  if (cached) {
+    return NextResponse.json(cached, {
+      headers: {
+        'Cache-Control': 'public, max-age=60, stale-while-revalidate=30',
+        'X-Cache': 'HIT',
+      },
+    })
   }
 
   const db = createServiceClient()
@@ -60,5 +73,12 @@ export async function GET(req: NextRequest) {
       : null,
   }
 
-  return NextResponse.json(chain)
+  await setCachedCert(id, chain)
+
+  return NextResponse.json(chain, {
+    headers: {
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=30',
+      'X-Cache': 'MISS',
+    },
+  })
 }

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,0 +1,66 @@
+/**
+ * Thin Upstash Redis cache wrapper.
+ * Falls back to no-op when UPSTASH_REDIS_REST_URL is not set (local dev / CI).
+ */
+
+const { UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN } = process.env
+
+const CERT_TTL = 60 // seconds
+
+function redisUrl(path: string) {
+  return `${UPSTASH_REDIS_REST_URL}${path}`
+}
+
+async function redisGet<T>(key: string): Promise<T | null> {
+  if (!UPSTASH_REDIS_REST_URL) return null
+  const res = await fetch(redisUrl(`/get/${encodeURIComponent(key)}`), {
+    headers: { Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}` },
+    cache: 'no-store',
+  })
+  const json = await res.json()
+  if (json.result == null) return null
+  console.log(`[cache] HIT ${key}`)
+  return JSON.parse(json.result) as T
+}
+
+async function redisSet(key: string, value: unknown, ttl: number): Promise<void> {
+  if (!UPSTASH_REDIS_REST_URL) return
+  await fetch(redisUrl(`/set/${encodeURIComponent(key)}`), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ value: JSON.stringify(value), ex: ttl }),
+    cache: 'no-store',
+  })
+  console.log(`[cache] SET ${key} ttl=${ttl}s`)
+}
+
+async function redisDel(key: string): Promise<void> {
+  if (!UPSTASH_REDIS_REST_URL) return
+  await fetch(redisUrl(`/del/${encodeURIComponent(key)}`), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}` },
+    cache: 'no-store',
+  })
+  console.log(`[cache] DEL ${key}`)
+}
+
+export function certCacheKey(id: string) {
+  return `cert:${id}`
+}
+
+export async function getCachedCert<T>(id: string): Promise<T | null> {
+  const hit = await redisGet<T>(certCacheKey(id))
+  if (!hit) console.log(`[cache] MISS ${certCacheKey(id)}`)
+  return hit
+}
+
+export async function setCachedCert(id: string, value: unknown): Promise<void> {
+  await redisSet(certCacheKey(id), value, CERT_TTL)
+}
+
+export async function invalidateCert(...ids: string[]): Promise<void> {
+  await Promise.all(ids.map((id) => redisDel(certCacheKey(id))))
+}


### PR DESCRIPTION
## Summary

Closes #43

Adds a Redis/Upstash caching layer for `GET /api/verify` to reduce Supabase load on frequently-read, rarely-changing certificate data.

## Changes

- **`src/lib/cache.ts`** — thin Upstash REST wrapper (no extra SDK dependency); falls back to no-op when `UPSTASH_REDIS_REST_URL` is unset
- **`api/verify/route.ts`** — cache lookup before DB query; sets `Cache-Control` and `X-Cache` headers; logs HIT/MISS
- **`api/readings/route.ts`** — invalidates cache entries (by cert ID, reading hash, mint tx hash) after a successful mint
- **`.env.example`** — documents the two new env vars

## Acceptance criteria

- [x] Redis/Upstash cache for certificate queries (TTL: 60 s)
- [x] Cache invalidated on mint events
- [x] `Cache-Control` headers set on responses
- [x] Cache hit/miss logged