### PR TITLE
feat: Supabase IaC migrations and CI validation

### DIFF
--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -1,0 +1,32 @@
+name: Supabase schema
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'supabase/**'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'supabase/**'
+
+jobs:
+  validate:
+    name: Validate migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase local stack
+        run: supabase start
+
+      - name: Reset DB (applies all migrations + seed)
+        run: supabase db reset
+
+      - name: Stop Supabase local stack
+        if: always()
+        run: supabase stop

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,27 @@
+# Supabase local dev config — https://supabase.com/docs/guides/cli/config
+project_id = "solarproof"
+
+[api]
+port = 54321
+schemas = ["public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 15
+
+[studio]
+port = 54323
+
+[inbucket]
+port = 54324
+
+[storage]
+file_size_limit = "50MiB"
+
+[auth]
+site_url = "http://localhost:3000"
+jwt_expiry = 3600
+enable_signup = true

--- a/supabase/migrations/20240101000001_initial_schema.sql
+++ b/supabase/migrations/20240101000001_initial_schema.sql
@@ -1,0 +1,45 @@
+-- Migration 001: initial schema
+-- Matches the schema documented in docs/DATABASE.md
+
+create table cooperatives (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  admin_address text not null,
+  created_at timestamptz not null default now()
+);
+
+create table meters (
+  id uuid primary key default gen_random_uuid(),
+  cooperative_id uuid not null references cooperatives(id) on delete cascade,
+  serial_number text not null unique,
+  pubkey_hex text not null,   -- Ed25519 public key (64 hex chars = 32 bytes)
+  active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+create table readings (
+  id uuid primary key default gen_random_uuid(),
+  meter_id uuid not null references meters(id) on delete cascade,
+  kwh numeric(12,4) not null check (kwh > 0),
+  timestamp timestamptz not null,
+  reading_hash text not null unique,   -- SHA-256 hex
+  signature_hex text not null,         -- Ed25519 signature hex (128 chars)
+  anchor_tx_hash text,
+  mint_tx_hash text,
+  anchored boolean not null default false,
+  minted boolean not null default false
+);
+
+create table certificates (
+  id uuid primary key default gen_random_uuid(),
+  cooperative_id uuid not null references cooperatives(id) on delete cascade,
+  reading_id uuid not null references readings(id),
+  reading_hash text not null,
+  anchor_tx_hash text not null,
+  mint_tx_hash text not null unique,
+  kwh numeric(12,4) not null,
+  issued_at timestamptz not null default now(),
+  retired boolean not null default false,
+  retired_at timestamptz,
+  retired_by text
+);

--- a/supabase/migrations/20240101000002_indexes.sql
+++ b/supabase/migrations/20240101000002_indexes.sql
@@ -1,0 +1,8 @@
+-- Migration 002: indexes for common query patterns
+
+create index on meters(cooperative_id);
+create index on readings(meter_id);
+create index on readings(reading_hash);
+create index on certificates(cooperative_id);
+create index on certificates(reading_hash);
+create index on certificates(mint_tx_hash);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,14 @@
+-- Seed data for local development
+-- Run automatically by: supabase db reset
+
+insert into cooperatives (id, name, admin_address) values
+  ('00000000-0000-0000-0000-000000000001', 'Demo Cooperative', 'GDEMO1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+
+insert into meters (id, cooperative_id, serial_number, pubkey_hex) values
+  (
+    '00000000-0000-0000-0000-000000000010',
+    '00000000-0000-0000-0000-000000000001',
+    'METER-001',
+    -- placeholder Ed25519 pubkey (32 zero bytes)
+    '0000000000000000000000000000000000000000000000000000000000000000'
+  );


### PR DESCRIPTION
## Summary

Closes #95

Replaces manual Supabase dashboard management with version-controlled migrations, enabling reproducible environments via `supabase db reset`.

## Files added

| File | Purpose |
|---|---|
| `supabase/config.toml` | Local dev stack configuration |
| `supabase/migrations/20240101000001_initial_schema.sql` | Full schema (cooperatives, meters, readings, certificates) |
| `supabase/migrations/20240101000002_indexes.sql` | Query performance indexes |
| `supabase/seed.sql` | Seed data loaded automatically by `supabase db reset` |
| `.github/workflows/supabase.yml` | CI: starts local stack, runs `supabase db reset`, validates all migrations apply cleanly |

## Usage

```bash
# Install Supabase CLI
brew install supabase/tap/supabase

# Start local stack + apply all migrations + seed
supabase start
supabase db reset

# Tear down
supabase stop
```

## Acceptance criteria

- [x] Full schema defined in `/supabase/migrations`
- [x] `supabase db reset` recreates schema from scratch
- [x] Seed data script for local development
- [x] CI validates schema against migrations