### PR TITLE
fix: add input validation to verify and retire API routes (#29)

### DIFF
--- a/apps/web/src/app/api/certificates/[id]/retire/route.ts
+++ b/apps/web/src/app/api/certificates/[id]/retire/route.ts
@@ -7,6 +7,10 @@ const RetireSchema = z.object({
   wallet_address: z.string().min(1),
 })
 
+const ParamsSchema = z.object({
+  id: z.string().uuid(),
+})
+
 /**
  * POST /api/certificates/[id]/retire
  *
@@ -19,7 +23,11 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params
+  const parsedParams = ParamsSchema.safeParse(await params)
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: parsedParams.error.flatten() }, { status: 400 })
+  }
+  const { id } = parsedParams.data
   const body = await req.json().catch(() => null)
   const parsed = RetireSchema.safeParse(body)
   if (!parsed.success) {

--- a/apps/web/src/app/api/verify/route.ts
+++ b/apps/web/src/app/api/verify/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { createServiceClient } from '@/lib/supabase'
 import { getCachedCert, setCachedCert } from '@/lib/cache'
+
+// UUID or 64-char hex hash (reading_hash / tx_hash)
+const VerifyQuerySchema = z.object({
+  id: z.string().regex(/^[0-9a-f]{64}$|^[0-9a-f-]{36}$/i, 'id must be a UUID or 64-char hex hash'),
+})
 
 /**
  * GET /api/verify?id=<certificate_id_or_reading_hash_or_tx_hash>
@@ -10,10 +16,11 @@ import { getCachedCert, setCachedCert } from '@/lib/cache'
  * Results are cached in Redis for 60 s (TTL defined in cache.ts).
  */
 export async function GET(req: NextRequest) {
-  const id = req.nextUrl.searchParams.get('id')?.trim()
-  if (!id) {
-    return NextResponse.json({ error: 'id parameter required' }, { status: 400 })
+  const parsed = VerifyQuerySchema.safeParse({ id: req.nextUrl.searchParams.get('id')?.trim() })
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   }
+  const { id } = parsed.data
 
   // Cache lookup
   const cached = await getCachedCert<unknown>(id)
@@ -26,14 +33,14 @@ export async function GET(req: NextRequest) {
     })
   }
 
-  const db = createServiceClient()
-
   // Try certificate ID first, then reading_hash, then mint_tx_hash
-  const { data: cert } = await db
-    .from('certificates')
-    .select('*')
-    .or(`id.eq.${id},reading_hash.eq.${id},mint_tx_hash.eq.${id}`)
-    .single()
+  // Use separate parameterised filters instead of raw .or() interpolation
+  const db = createServiceClient()
+  let cert = null
+  for (const column of ['id', 'reading_hash', 'mint_tx_hash'] as const) {
+    const { data } = await db.from('certificates').select('*').eq(column, id).maybeSingle()
+    if (data) { cert = data; break }
+  }
 
   if (!cert) {
     return NextResponse.json({ error: 'Certificate not found' }, { status: 404 })


### PR DESCRIPTION
Closes #29                                                                  
                                                                                 
  Two API routes were accepting unvalidated input, creating injection and        
  unexpected-behaviour risks.                                                    
                                                                                 
  Changes                                                                        
                                                                                 
  GET /api/verify                                                                
                                                                                 
  - Added VerifyQuerySchema (Zod) — id must be a UUID or 64-char hex string;     
  anything else returns a structured 400                                         
  - Replaced raw .or(\id.eq.${id},...\) string interpolation with a parameterised
  .eq() loop, eliminating the query injection vector                             
                                                                                 
  POST /api/certificates/[id]/retire                                             
                                                                                 
  - Added ParamsSchema (Zod) — validates the [id] path param as a UUID before any
  business logic or DB access                                                    
                                                                                 
  No changes needed                                                              
                                                                                 
  - POST /api/readings — already had ReadingSchema ✅                            
  - POST /api/certificates/[id]/retire body — already had RetireSchema ✅        
  - GET /api/health — no user input ✅                                           
                                                                                 
  Acceptance criteria                                                            
                                                                                 
  - [x] Zod schemas for all request bodies and query/path params                 
  - [x] 400 with structured error on validation failure                          
  - [x] No dynamic queries built from raw user input                             
  - [x] Validation applied before any business logic                             
                                                                                 
                                                       
                           