### PR TITLE
feat(web): add custom 404 and 500 error pages [#22]

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useId } from 'react'
+import Link from 'next/link'
+import { AlertTriangle } from 'lucide-react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const fallbackId = useId()
+  const referenceId = error.digest ?? fallbackId
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
+      <AlertTriangle className="h-12 w-12 text-red-500" aria-hidden="true" />
+      <h1 className="text-6xl font-bold text-gray-900 dark:text-gray-100">500</h1>
+      <p className="text-xl text-gray-600 dark:text-gray-400">Something went wrong</p>
+      <p className="max-w-md text-gray-500 dark:text-gray-500">
+        An unexpected error occurred. Please try again or contact support if the problem persists.
+      </p>
+      <p className="font-mono text-sm text-gray-400 dark:text-gray-600">
+        Reference ID: <span className="select-all">{referenceId}</span>
+      </p>
+      <div className="flex gap-4">
+        <button
+          onClick={reset}
+          className="rounded-lg bg-yellow-400 px-6 py-3 font-semibold text-gray-900 transition hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2"
+        >
+          Try again
+        </button>
+        <Link
+          href="/dashboard"
+          className="rounded-lg border border-gray-300 px-6 py-3 font-semibold text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { Sun } from 'lucide-react'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
+      <Sun className="h-12 w-12 text-yellow-400" aria-hidden="true" />
+      <h1 className="text-6xl font-bold text-gray-900 dark:text-gray-100">404</h1>
+      <p className="text-xl text-gray-600 dark:text-gray-400">Page not found</p>
+      <p className="max-w-md text-gray-500 dark:text-gray-500">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Link
+        href="/dashboard"
+        className="rounded-lg bg-yellow-400 px-6 py-3 font-semibold text-gray-900 transition hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2"
+      >
+        Back to Dashboard
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Replaces Next.js default error pages with branded SolarProof pages.

## Changes

### `apps/web/src/app/not-found.tsx`
- Custom 404 page with SolarProof Sun icon
- Clear messaging and a direct link back to `/dashboard`
- Responsive, accessible (aria-hidden on decorative icon)

### `apps/web/src/app/error.tsx`
- Custom 500 error boundary (`'use client'` as required by Next.js App Router)
- Displays `error.digest` as the reference ID (falls back to `useId()` if not set)
- "Try again" button calls `reset()` to re-render the segment
- Link back to `/dashboard`
- Logs error to console via `useEffect`

## Acceptance Criteria

- [x] Custom 404 page with navigation back to dashboard
- [x] Custom 500 page with error reference ID
- [x] Both pages are accessible and responsive

Closes #22