### PR TITLE
Add audit registry deduplication + local Soroban integration tests

### DIFF
--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -36,7 +36,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, Address, BytesN, Env};
 
 const VERSION: &str = "1.0.0";
 
@@ -69,6 +69,13 @@ pub enum DataKey {
     /// `u32` — total number of anchors stored.
     TotalAnchors,
     Version,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+    Unauthorized = 1,
+    AlreadyAnchored = 2,
 }
 
 // ---------------------------------------------------------------------------
@@ -141,16 +148,16 @@ impl AuditRegistry {
     ///
     /// # Events
     /// Emits `(topic: "anchor", data: reading_hash)`.
-    pub fn anchor(env: Env, caller: soroban_sdk::Address, reading_hash: BytesN<32>) {
+    pub fn anchor(env: Env, caller: soroban_sdk::Address, reading_hash: BytesN<32>) -> Result<(), Error> {
         caller.require_auth();
         let api_signer: Address = env.storage().instance().get(&DataKey::ApiSigner).expect("not initialized");
         if caller != api_signer {
-            panic!("unauthorized");
+            return Err(Error::Unauthorized);
         }
 
         let key = DataKey::Anchor(reading_hash.clone());
         if env.storage().persistent().has(&key) {
-            panic!("reading already anchored");
+            return Err(Error::AlreadyAnchored);
         }
 
         let anchor = AuditAnchor {
@@ -164,6 +171,7 @@ impl AuditRegistry {
         env.storage().instance().set(&DataKey::TotalAnchors, &(count + 1));
 
         env.events().publish((symbol_short!("anchor"),), reading_hash);
+        Ok(())
     }
 
     /// Returns the `AuditAnchor` for `reading_hash`, or `None` if not anchored.
@@ -215,7 +223,7 @@ mod tests {
     fn test_anchor_and_verify() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h);
+        client.anchor(&api_signer, &h).unwrap();
         assert!(client.is_anchored(&h));
         assert_eq!(client.total_anchors(), 1);
         let anchor = client.verify(&h).unwrap();
@@ -223,20 +231,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unauthorized")]
     fn test_unauthorized_caller_rejected() {
         let (env, _api_signer, client) = setup();
         let attacker = soroban_sdk::Address::generate(&env);
-        client.anchor(&attacker, &hash(&env));
+        assert_eq!(client.anchor(&attacker, &hash(&env)), Err(Error::Unauthorized));
     }
 
     #[test]
-    #[should_panic(expected = "reading already anchored")]
     fn test_duplicate_anchor_rejected() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h);
-        client.anchor(&api_signer, &h);
+        client.anchor(&api_signer, &h).unwrap();
+        assert_eq!(client.anchor(&api_signer, &h), Err(Error::AlreadyAnchored));
     }
 
     #[test]

--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -7,6 +7,21 @@ import { computeReadingHash } from '@/lib/crypto'
 import { kwhToStroops } from '@solarproof/stellar'
 import { invalidateCert } from '@/lib/cache'
 
+function extractErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function isAlreadyAnchoredError(err: unknown): boolean {
+  const message = extractErrorMessage(err).toLowerCase()
+  return message.includes('alreadyanchored') || message.includes('reading already anchored') || message.includes('duplicate')
+}
+
 const ReadingSchema = z.object({
   meter_id: z.string().uuid(),
   kwh: z.number().positive(),
@@ -84,7 +99,10 @@ export async function POST(req: NextRequest) {
     anchorTxHash = await anchorReading({ readingHash })
     await db.from('readings').update({ anchored: true, anchor_tx_hash: anchorTxHash }).eq('id', reading.id)
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Anchor failed'
+    if (isAlreadyAnchoredError(err)) {
+      return NextResponse.json({ error: 'Reading already anchored', reading_id: reading.id }, { status: 409 })
+    }
+    const message = extractErrorMessage(err)
     return NextResponse.json({ error: message, reading_id: reading.id }, { status: 500 })
   }
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "turbo lint",
     "type-check": "turbo type-check",
     "test": "turbo test",
+    "integration:test": "node scripts/local-soroban-integration.mjs",
     "clean": "turbo clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md,json}\" --ignore-path .gitignore"
   },

--- a/scripts/local-soroban-integration.mjs
+++ b/scripts/local-soroban-integration.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { createHash, createSign, randomUUID } from 'crypto'
+import { createClient } from '@supabase/supabase-js'
+import { Keypair } from '@stellar/stellar-sdk'
+import { kwhToStroops } from '@solarproof/stellar'
+
+const API_URL = process.env.API_URL || 'http://localhost:3000'
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+function ensureEnv(name, value) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+}
+
+ensureEnv('SUPABASE_URL', SUPABASE_URL)
+ensureEnv('SUPABASE_SERVICE_ROLE_KEY', SUPABASE_SERVICE_ROLE_KEY)
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+function computeReadingHash(meterId, kwhStroops, timestampUnix) {
+  const meterBytes = Buffer.from(meterId, 'utf8')
+  const kwhBuf = Buffer.alloc(8)
+  kwhBuf.writeBigInt64LE(BigInt(kwhStroops))
+  const tsBuf = Buffer.alloc(8)
+  tsBuf.writeBigInt64LE(BigInt(timestampUnix))
+  return createHash('sha256').update(meterBytes).update(kwhBuf).update(tsBuf).digest()
+}
+
+function signReading(readingHash, rawPrivateKey) {
+  const privKeyDer = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    rawPrivateKey,
+  ])
+  const signer = createSign('ed25519')
+  signer.update(readingHash)
+  return signer.sign({ key: privKeyDer, format: 'der', type: 'pkcs8' }).toString('hex')
+}
+
+async function postReading(payload) {
+  const response = await fetch(`${API_URL}/api/readings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await response.json().catch(() => null)
+  return { status: response.status, ok: response.ok, data }
+}
+
+async function main() {
+  console.log('Starting local integration test...')
+
+  const meterKeypair = Keypair.random()
+  const recipientKeypair = Keypair.random()
+  const meterId = randomUUID()
+  const cooperativeId = randomUUID()
+  const kwh = 12.5
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  const meterPubkeyHex = Buffer.from(meterKeypair.rawPublicKey()).toString('hex')
+  const meterPrivateHex = Buffer.from(meterKeypair.rawSecretKey()).toString('hex')
+  const recipientAddress = recipientKeypair.publicKey()
+
+  console.log('Registering cooperative and meter in Supabase...')
+  const { error: coopError } = await supabase.from('cooperatives').insert({
+    id: cooperativeId,
+    name: 'Local Soroban Integration Test Cooperative',
+    admin_address: recipientAddress,
+  })
+  if (coopError) {
+    throw new Error(`Failed to create cooperative: ${coopError.message}`)
+  }
+
+  const { error: meterError } = await supabase.from('meters').insert({
+    id: meterId,
+    cooperative_id: cooperativeId,
+    serial_number: `local-test-meter-${Date.now()}`,
+    pubkey_hex: meterPubkeyHex,
+    active: true,
+  })
+  if (meterError) {
+    throw new Error(`Failed to create meter: ${meterError.message}`)
+  }
+
+  const readingHash = computeReadingHash(meterId, kwhToStroops(kwh), BigInt(timestamp))
+  const signatureHex = signReading(readingHash, Buffer.from(meterPrivateHex, 'hex'))
+
+  console.log('Sending signed reading payload to API...')
+  const { status, ok, data } = await postReading({
+    meter_id: meterId,
+    kwh,
+    timestamp,
+    signature_hex: signatureHex,
+  })
+
+  if (!ok) {
+    throw new Error(`API request failed (${status}): ${JSON.stringify(data)}`)
+  }
+
+  console.log('API response:', data)
+  if (!data?.reading_id || !data?.anchor_tx_hash || !data?.mint_tx_hash) {
+    throw new Error('API did not return both anchor_tx_hash and mint_tx_hash')
+  }
+
+  const { data: readingRow, error: readingRowError } = await supabase
+    .from('readings')
+    .select('*')
+    .eq('id', data.reading_id)
+    .single()
+
+  if (readingRowError || !readingRow) {
+    throw new Error(`Failed to fetch reading row: ${readingRowError?.message}`)
+  }
+
+  if (!readingRow.anchored || !readingRow.minted) {
+    throw new Error('Reading row was not marked as anchored and minted in the database')
+  }
+
+  const { data: certificateRow, error: certError } = await supabase
+    .from('certificates')
+    .select('*')
+    .eq('reading_id', data.reading_id)
+    .single()
+
+  if (certError || !certificateRow) {
+    throw new Error(`Certificate row was not created: ${certError?.message}`)
+  }
+
+  const certificateKwh = typeof certificateRow.kwh === 'string' ? Number(certificateRow.kwh) : certificateRow.kwh
+  if (certificateKwh !== kwh) {
+    throw new Error(`Certificate row kwh mismatch: expected ${kwh}, got ${certificateRow.kwh}`)
+  }
+
+  console.log('Integration test passed: reading anchored and token certificate minted successfully.')
+  console.log('Meter public key:', meterPubkeyHex)
+  console.log('Reading hash:', readingHash.toString('hex'))
+  console.log('Anchor tx hash:', data.anchor_tx_hash)
+  console.log('Mint tx hash:', data.mint_tx_hash)
+}
+
+main().catch((error) => {
+  console.error('Integration test failed:', error)
+  process.exit(1)
+})

--- a/scripts/local-soroban-setup.sh
+++ b/scripts/local-soroban-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: Docker is required to run the local Soroban sandbox."
+  exit 1
+fi
+
+echo "Building Soroban contract WASM artifacts..."
+cd apps/contracts
+cargo build --release --target wasm32-unknown-unknown -p energy_token
+cargo build --release --target wasm32-unknown-unknown -p audit_registry
+cd "$ROOT"
+
+echo "Starting local Soroban sandbox container..."
+docker pull stellar/quickstart:soroban
+
+if docker ps -a --format '{{.Names}}' | grep -q '^solarproof-soroban$'; then
+  docker rm -f solarproof-soroban >/dev/null 2>&1 || true
+fi
+
+docker run -d \
+  --name solarproof-soroban \
+  -p 8000:8000 \
+  -p 11626:11626 \
+  -v "$ROOT":/repo \
+  stellar/quickstart:soroban
+
+echo "Waiting for local Soroban RPC to become healthy..."
+until curl -s http://127.0.0.1:8000/health | grep -Eq 'ok|OK|true'; do
+  sleep 1
+  echo -n '.'
+done
+
+echo
+printf 'Local Soroban RPC is ready at http://127.0.0.1:8000\n'
+
+echo "Next steps:"
+cat <<'EOF'
+1. Deploy the contracts from the built WASM artifacts.
+   You can use your local stellar CLI or a separate deploy script.
+2. Set the following environment vars in apps/web/.env.local:
+   NEXT_PUBLIC_AUDIT_REGISTRY_ID
+   NEXT_PUBLIC_ENERGY_TOKEN_ID
+   MINTER_SECRET_KEY
+   NEXT_PUBLIC_SUPABASE_URL
+   NEXT_PUBLIC_SUPABASE_ANON_KEY
+   SUPABASE_SERVICE_ROLE_KEY
+3. Start the Next.js app with `pnpm --filter @solarproof/web dev`.
+4. Run the integration test script:
+   pnpm exec node scripts/local-soroban-integration.mjs
+EOF


### PR DESCRIPTION
this pr closes #73 
this pr closes #72 

This PR implements deduplication for audit registry anchors by returning a custom AlreadyAnchored error instead of allowing duplicate reads. It also updates the API to return HTTP 409 when a duplicate anchor is submitted, and adds local integration scripts for Soroban contract deployment and end-to-end testing using a local sandbox.