### PR TITLE
ci: branch protection rules for main and develop (#81)

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,79 @@
+name: Apply Branch Protection
+
+# Runs automatically when this file changes on main, and can be triggered manually.
+# Requires a PAT with `administration:write` stored as BRANCH_PROTECTION_TOKEN.
+# Falls back to GITHUB_TOKEN for read-only checks (protection won't be applied without the PAT).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/branch-protection.yml
+  workflow_dispatch:
+
+jobs:
+  protect:
+    name: Apply branch protection rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Protect main
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/branches/main/protection \
+            --input - <<'EOF'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "contexts": [
+                "Web (lint + type-check + test + build)",
+                "Contracts (fmt + clippy + test)"
+              ]
+            },
+            "enforce_admins": true,
+            "required_pull_request_reviews": {
+              "required_approving_review_count": 1,
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": false
+            },
+            "restrictions": null,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "block_creations": false,
+            "required_conversation_resolution": true
+          }
+          EOF
+
+      - name: Protect develop
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/branches/develop/protection \
+            --input - <<'EOF'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "contexts": [
+                "Web (lint + type-check + test + build)",
+                "Contracts (fmt + clippy + test)"
+              ]
+            },
+            "enforce_admins": false,
+            "required_pull_request_reviews": {
+              "required_approving_review_count": 1,
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": false
+            },
+            "restrictions": null,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "block_creations": false,
+            "required_conversation_resolution": true
+          }
+          EOF

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,33 @@
+# Branch Protection
+
+Branch protection rules for `main` and `develop` are applied automatically by the
+[`branch-protection` workflow](.github/workflows/branch-protection.yml).
+
+## Rules (both branches)
+
+| Rule | Value |
+|---|---|
+| Required approvals | 1 |
+| Dismiss stale reviews on new commits | ✅ |
+| Require CI to pass before merge | ✅ (see required checks below) |
+| Allow force pushes | ❌ |
+| Allow branch deletion | ❌ |
+| Require conversation resolution | ✅ |
+
+`main` additionally enforces rules for admins (`enforce_admins: true`).
+
+## Required CI checks
+
+- `Web (lint + type-check + test + build)` — from `.github/workflows/ci.yml`
+- `Contracts (fmt + clippy + test)` — from `.github/workflows/ci.yml`
+
+## Setup
+
+The workflow requires a **Personal Access Token** with `administration:write` scope:
+
+1. Create a PAT: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained
+   - Repository: `AnnabelJoe/solarproof`
+   - Permissions: `Administration` → Read and write
+2. Add it as a repository secret: Settings → Secrets → `BRANCH_PROTECTION_TOKEN`
+3. The workflow runs automatically on the next push to `main`, or trigger it manually via
+   Actions → *Apply Branch Protection* → *Run workflow*.


### PR DESCRIPTION
## Summary

Closes #81

## Changes

### `.github/workflows/branch-protection.yml` (new)
A workflow that calls the GitHub REST API to apply branch protection rules to `main` and `develop`. Runs automatically when the file changes on `main`, and can be triggered manually via `workflow_dispatch`.

### `docs/BRANCH_PROTECTION.md` (new)
Documents the rules and the one-time PAT setup required.

## Rules applied

| Rule | main | develop |
|---|---|---|
| Required approvals | 1 | 1 |
| Dismiss stale reviews | ✅ | ✅ |
| CI must pass before merge | ✅ | ✅ |
| No force pushes | ✅ | ✅ |
| No branch deletion | ✅ | ✅ |
| Enforce for admins | ✅ | ❌ |

## Required CI checks

- `Web (lint + type-check + test + build)`
- `Contracts (fmt + clippy + test)`

## One-time setup

Add a PAT with `administration:write` as the `BRANCH_PROTECTION_TOKEN` repository secret (see `docs/BRANCH_PROTECTION.md`).

## Acceptance criteria

- [x] Require PR with at least 1 approval
- [x] Require CI to pass before merge
- [x] No force pushes to main/develop
- [x] Stale review dismissal on new commits