### PR TITLE
feat: wallet persistence, toast notifications, certificate retirement, energy charts

### DIFF
--- a/apps/web/src/app/api/certificates/route.ts
+++ b/apps/web/src/app/api/certificates/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+
+export async function GET() {
+  const db = createServiceClient()
+  const { data, error } = await db
+    .from('certificates')
+    .select('id, kwh, minted_at, retired, retired_at, retired_by, tx_hash')
+    .order('minted_at', { ascending: false })
+    .limit(100)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data ?? [])
+}

--- a/apps/web/src/app/certificates/page.tsx
+++ b/apps/web/src/app/certificates/page.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Award, Leaf } from 'lucide-react'
+import { RetireModal } from '@/components/retire-modal'
+import { useToast } from '@/components/toast'
+import { useWallet } from '@/hooks/useWallet'
+
+interface Certificate {
+  id: string
+  kwh: number
+  minted_at: string
+  retired: boolean
+  retired_at: string | null
+  retired_by: string | null
+  tx_hash: string | null
+}
+
+async function fetchCertificates(): Promise<Certificate[]> {
+  const res = await fetch('/api/certificates')
+  if (!res.ok) throw new Error('Failed to load certificates')
+  return res.json()
+}
+
+export default function CertificatesPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['certificates'],
+    queryFn: fetchCertificates,
+  })
+  const qc = useQueryClient()
+  const { toast, dismiss } = useToast()
+  const { address, connected, connect } = useWallet()
+  const [retiring, setRetiring] = useState<Certificate | null>(null)
+
+  async function handleRetire(reason: string) {
+    if (!retiring) return
+    const pendingId = toast('pending', 'Submitting retirement transaction…')
+    try {
+      const res = await fetch(`/api/certificates/${retiring.id}/retire`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ wallet_address: address, reason }),
+      })
+      dismiss(pendingId)
+      if (!res.ok) {
+        const { error: msg } = await res.json().catch(() => ({ error: 'Unknown error' }))
+        toast('error', msg ?? 'Retirement failed')
+        return
+      }
+      toast('success', 'Certificate retired successfully')
+      setRetiring(null)
+      qc.invalidateQueries({ queryKey: ['certificates'] })
+    } catch (err) {
+      dismiss(pendingId)
+      toast('error', err instanceof Error ? err.message : 'Retirement failed')
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">Certificates</h1>
+
+      {!connected && (
+        <div className="mb-6 flex items-center justify-between rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 dark:border-yellow-800 dark:bg-yellow-950">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200">
+            Connect your wallet to retire certificates.
+          </p>
+          <button
+            onClick={() => connect().catch(() => {})}
+            className="rounded-md bg-yellow-400 px-3 py-1.5 text-xs font-medium text-gray-900 hover:bg-yellow-500"
+          >
+            Connect wallet
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="mb-4 text-sm text-red-600 dark:text-red-400">
+          Failed to load certificates.
+        </p>
+      )}
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-800">
+        <div className="overflow-x-auto">
+          <table
+            className="min-w-full divide-y divide-gray-200 bg-white text-sm dark:divide-gray-800 dark:bg-gray-900"
+            aria-label="Energy certificates"
+            aria-busy={isLoading}
+          >
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-800/50">
+                {['Certificate ID', 'kWh', 'Minted', 'Status', 'Action'].map((h) => (
+                  <th
+                    key={h}
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-400">
+                    Loading…
+                  </td>
+                </tr>
+              ) : data && data.length > 0 ? (
+                data.map((cert) => (
+                  <tr key={cert.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/40">
+                    <td className="px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
+                      {cert.id.slice(0, 8)}…
+                    </td>
+                    <td className="px-4 py-3 text-gray-900 dark:text-gray-100">{cert.kwh}</td>
+                    <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+                      {new Date(cert.minted_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      {cert.retired ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                          <Leaf className="h-3 w-3" aria-hidden="true" />
+                          Retired
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                          <Award className="h-3 w-3" aria-hidden="true" />
+                          Active
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {!cert.retired && (
+                        <button
+                          onClick={() => setRetiring(cert)}
+                          disabled={!connected}
+                          aria-label={`Retire certificate ${cert.id.slice(0, 8)}`}
+                          className="rounded-md bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          Retire
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                    No certificates found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {retiring && (
+        <RetireModal
+          certificateId={retiring.id}
+          kwh={retiring.kwh}
+          onConfirm={handleRetire}
+          onClose={() => setRetiring(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -14,8 +14,9 @@ import {
   Legend,
 } from 'recharts'
 import { useTheme } from 'next-themes'
-import { Zap, Award, Leaf, TrendingUp } from 'lucide-react'
+import { Zap, Award, Leaf, TrendingUp, Download } from 'lucide-react'
 import { StatCardSkeleton, ChartSkeleton, TableRowSkeleton } from '@/components/skeleton'
+import { useState } from 'react'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,8 +36,10 @@ interface Stats {
   active_meters: number
 }
 
+type Period = 'daily' | 'weekly' | 'monthly'
+
 // ---------------------------------------------------------------------------
-// Mock fetch helpers (replace with real API calls)
+// Fetch helpers
 // ---------------------------------------------------------------------------
 async function fetchStats(): Promise<Stats> {
   const res = await fetch('/api/readings?type=stats')
@@ -76,7 +79,7 @@ function StatCard({ label, value, icon: Icon, description }: StatCardProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Chart colours that respect dark mode
+// Accessible chart colours (WCAG AA contrast, colour-blind safe)
 // ---------------------------------------------------------------------------
 function useChartColors() {
   const { resolvedTheme } = useTheme()
@@ -84,10 +87,10 @@ function useChartColors() {
   return {
     grid: dark ? '#374151' : '#e5e7eb',
     text: dark ? '#9ca3af' : '#6b7280',
-    area: dark ? '#fbbf24' : '#f59e0b',
-    areaFill: dark ? '#fbbf2440' : '#fef3c7',
-    bar1: dark ? '#fbbf24' : '#f59e0b',
-    bar2: dark ? '#34d399' : '#10b981',
+    area: '#f59e0b',
+    areaFill: dark ? '#f59e0b33' : '#fef3c7',
+    bar1: '#f59e0b', // amber — generation
+    bar2: '#0ea5e9', // sky blue — distinct from amber, CB-safe
     tooltip: {
       bg: dark ? '#1f2937' : '#ffffff',
       border: dark ? '#374151' : '#e5e7eb',
@@ -97,9 +100,66 @@ function useChartColors() {
 }
 
 // ---------------------------------------------------------------------------
+// Grouping helpers
+// ---------------------------------------------------------------------------
+function groupByPeriod(readings: Reading[], period: Period): { date: string; kwh: number }[] {
+  const map: Record<string, number> = {}
+  for (const r of readings) {
+    const d = new Date(r.timestamp)
+    let key: string
+    if (period === 'daily') {
+      key = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    } else if (period === 'weekly') {
+      // ISO week label: "W{n} MMM"
+      const startOfYear = new Date(d.getFullYear(), 0, 1)
+      const week = Math.ceil(((d.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+      key = `W${week} ${d.toLocaleDateString('en-US', { month: 'short' })}`
+    } else {
+      key = d.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
+    }
+    map[key] = (map[key] ?? 0) + r.kwh
+  }
+  const limit = period === 'daily' ? 14 : period === 'weekly' ? 12 : 12
+  return Object.entries(map)
+    .slice(-limit)
+    .map(([date, kwh]) => ({ date, kwh: Math.round(kwh * 100) / 100 }))
+}
+
+function groupByMeter(readings: Reading[]): { meter: string; verified: number; unverified: number }[] {
+  const map: Record<string, { verified: number; unverified: number }> = {}
+  for (const r of readings) {
+    if (!map[r.meter_id]) map[r.meter_id] = { verified: 0, unverified: 0 }
+    if (r.verified) map[r.meter_id].verified += r.kwh
+    else map[r.meter_id].unverified += r.kwh
+  }
+  return Object.entries(map).map(([meter, counts]) => ({
+    meter,
+    verified: Math.round(counts.verified * 100) / 100,
+    unverified: Math.round(counts.unverified * 100) / 100,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+function exportCsv(rows: { date: string; kwh: number }[], filename: string) {
+  const header = 'date,kwh'
+  const body = rows.map((r) => `${r.date},${r.kwh}`).join('\n')
+  const blob = new Blob([`${header}\n${body}`], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+// ---------------------------------------------------------------------------
 // Dashboard page
 // ---------------------------------------------------------------------------
 export default function DashboardPage() {
+  const [period, setPeriod] = useState<Period>('daily')
+
   const {
     data: stats,
     isLoading: statsLoading,
@@ -113,198 +173,139 @@ export default function DashboardPage() {
   } = useQuery({ queryKey: ['readings'], queryFn: fetchReadings })
 
   const colors = useChartColors()
-
-  // Build chart data from readings (group by date)
-  const chartData = readings
-    ? Object.entries(
-        readings.reduce<Record<string, number>>((acc, r) => {
-          const date = new Date(r.timestamp).toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-          })
-          acc[date] = (acc[date] ?? 0) + r.kwh
-          return acc
-        }, {})
-      )
-        .slice(-14)
-        .map(([date, kwh]) => ({ date, kwh }))
-    : []
+  const chartData = readings ? groupByPeriod(readings, period) : []
+  const meterData = readings ? groupByMeter(readings) : []
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Stat cards                                                           */}
-      {/* ------------------------------------------------------------------ */}
+      {/* Stat cards */}
       <section aria-labelledby="stats-heading" className="mb-8">
-        <h2 id="stats-heading" className="sr-only">
-          Key statistics
-        </h2>
-
+        <h2 id="stats-heading" className="sr-only">Key statistics</h2>
         {statsError && (
-          <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-            Failed to load statistics.
-          </p>
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">Failed to load statistics.</p>
         )}
-
         <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
           {statsLoading ? (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
+            <><StatCardSkeleton /><StatCardSkeleton /><StatCardSkeleton /><StatCardSkeleton /></>
           ) : stats ? (
             <>
-              <StatCard
-                label="Total energy"
-                value={`${stats.total_kwh.toLocaleString()} kWh`}
-                icon={Zap}
-                description="All verified readings"
-              />
-              <StatCard
-                label="Certificates issued"
-                value={stats.certificates_issued.toLocaleString()}
-                icon={Award}
-                description="Minted on Stellar"
-              />
-              <StatCard
-                label="Certificates retired"
-                value={stats.certificates_retired.toLocaleString()}
-                icon={Leaf}
-                description="Permanently burned"
-              />
-              <StatCard
-                label="Active meters"
-                value={stats.active_meters.toLocaleString()}
-                icon={TrendingUp}
-                description="Reporting in last 24 h"
-              />
+              <StatCard label="Total energy" value={`${stats.total_kwh.toLocaleString()} kWh`} icon={Zap} description="All verified readings" />
+              <StatCard label="Certificates issued" value={stats.certificates_issued.toLocaleString()} icon={Award} description="Minted on Stellar" />
+              <StatCard label="Certificates retired" value={stats.certificates_retired.toLocaleString()} icon={Leaf} description="Permanently burned" />
+              <StatCard label="Active meters" value={stats.active_meters.toLocaleString()} icon={TrendingUp} description="Reporting in last 24 h" />
             </>
           ) : null}
         </div>
       </section>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Charts                                                               */}
-      {/* ------------------------------------------------------------------ */}
+      {/* Charts */}
       <section aria-labelledby="charts-heading" className="mb-8">
-        <h2 id="charts-heading" className="sr-only">
-          Energy charts
-        </h2>
+        <h2 id="charts-heading" className="sr-only">Energy charts</h2>
 
         <div className="grid gap-6 lg:grid-cols-2">
-          {/* Area chart — daily kWh */}
+          {/* Line/area chart — kWh over time with period selector */}
           {readingsLoading ? (
-            <ChartSkeleton title="Daily energy output" />
+            <ChartSkeleton title="Energy output" />
           ) : (
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-              <h3 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Daily energy output (kWh)
-              </h3>
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  Energy output (kWh)
+                </h3>
+                <div className="flex items-center gap-2">
+                  {/* Period selector */}
+                  <fieldset className="flex rounded-md border border-gray-200 dark:border-gray-700">
+                    <legend className="sr-only">Time period</legend>
+                    {(['daily', 'weekly', 'monthly'] as Period[]).map((p) => (
+                      <label key={p} className="cursor-pointer">
+                        <input
+                          type="radio"
+                          name="period"
+                          value={p}
+                          checked={period === p}
+                          onChange={() => setPeriod(p)}
+                          className="sr-only"
+                        />
+                        <span
+                          className={`block px-2.5 py-1 text-xs font-medium capitalize transition-colors first:rounded-l-md last:rounded-r-md ${
+                            period === p
+                              ? 'bg-yellow-400 text-gray-900'
+                              : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                          }`}
+                        >
+                          {p}
+                        </span>
+                      </label>
+                    ))}
+                  </fieldset>
+                  {/* CSV export */}
+                  <button
+                    onClick={() => exportCsv(chartData, `energy-${period}.csv`)}
+                    aria-label={`Export ${period} energy data as CSV`}
+                    className="rounded-md border border-gray-200 p-1.5 text-gray-500 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                  >
+                    <Download className="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                </div>
+              </div>
               <div
                 role="img"
-                aria-label="Area chart showing daily energy output in kWh over the last 14 days"
+                aria-label={`Area chart showing ${period} energy output in kWh`}
                 className="h-48 w-full"
               >
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
-                    <XAxis
-                      dataKey="date"
-                      tick={{ fontSize: 11, fill: colors.text }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 11, fill: colors.text }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
+                    <XAxis dataKey="date" tick={{ fontSize: 11, fill: colors.text }} tickLine={false} axisLine={false} />
+                    <YAxis tick={{ fontSize: 11, fill: colors.text }} tickLine={false} axisLine={false} />
                     <Tooltip
-                      contentStyle={{
-                        backgroundColor: colors.tooltip.bg,
-                        border: `1px solid ${colors.tooltip.border}`,
-                        borderRadius: '8px',
-                        color: colors.tooltip.text,
-                        fontSize: '12px',
-                      }}
+                      contentStyle={{ backgroundColor: colors.tooltip.bg, border: `1px solid ${colors.tooltip.border}`, borderRadius: '8px', color: colors.tooltip.text, fontSize: '12px' }}
                     />
-                    <Area
-                      type="monotone"
-                      dataKey="kwh"
-                      stroke={colors.area}
-                      fill={colors.areaFill}
-                      strokeWidth={2}
-                      name="kWh"
-                    />
+                    <Area type="monotone" dataKey="kwh" stroke={colors.area} fill={colors.areaFill} strokeWidth={2} name="kWh" />
                   </AreaChart>
                 </ResponsiveContainer>
               </div>
             </div>
           )}
 
-          {/* Bar chart — verified vs unverified */}
+          {/* Bar chart — per-meter kWh breakdown */}
           {readingsLoading ? (
-            <ChartSkeleton title="Verification status" />
+            <ChartSkeleton title="Per-meter breakdown" />
           ) : (
             <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-gray-900">
-              <h3 className="mb-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Verification status by meter
-              </h3>
+              <div className="mb-4 flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  Per-meter kWh breakdown
+                </h3>
+                <button
+                  onClick={() => {
+                    const rows = meterData.map((m) => ({ date: m.meter, kwh: m.verified + m.unverified }))
+                    exportCsv(rows, 'energy-by-meter.csv')
+                  }}
+                  aria-label="Export per-meter data as CSV"
+                  className="rounded-md border border-gray-200 p-1.5 text-gray-500 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+                >
+                  <Download className="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+              </div>
               <div
                 role="img"
-                aria-label="Bar chart showing verified and unverified readings per meter"
+                aria-label="Bar chart showing verified and unverified kWh per meter"
                 className="h-48 w-full"
               >
                 <ResponsiveContainer width="100%" height="100%">
-                  <BarChart
-                    data={
-                      readings
-                        ? Object.entries(
-                            readings.reduce<Record<string, { verified: number; unverified: number }>>(
-                              (acc, r) => {
-                                if (!acc[r.meter_id])
-                                  acc[r.meter_id] = { verified: 0, unverified: 0 }
-                                if (r.verified) acc[r.meter_id].verified++
-                                else acc[r.meter_id].unverified++
-                                return acc
-                              },
-                              {}
-                            )
-                          ).map(([meter, counts]) => ({ meter, ...counts }))
-                        : []
-                    }
-                    margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
-                  >
+                  <BarChart data={meterData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} />
-                    <XAxis
-                      dataKey="meter"
-                      tick={{ fontSize: 11, fill: colors.text }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 11, fill: colors.text }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
+                    <XAxis dataKey="meter" tick={{ fontSize: 11, fill: colors.text }} tickLine={false} axisLine={false} />
+                    <YAxis tick={{ fontSize: 11, fill: colors.text }} tickLine={false} axisLine={false} />
                     <Tooltip
-                      contentStyle={{
-                        backgroundColor: colors.tooltip.bg,
-                        border: `1px solid ${colors.tooltip.border}`,
-                        borderRadius: '8px',
-                        color: colors.tooltip.text,
-                        fontSize: '12px',
-                      }}
+                      contentStyle={{ backgroundColor: colors.tooltip.bg, border: `1px solid ${colors.tooltip.border}`, borderRadius: '8px', color: colors.tooltip.text, fontSize: '12px' }}
                     />
-                    <Legend
-                      wrapperStyle={{ fontSize: '12px', color: colors.text }}
-                    />
-                    <Bar dataKey="verified" fill={colors.bar1} name="Verified" radius={[4, 4, 0, 0]} />
-                    <Bar dataKey="unverified" fill={colors.bar2} name="Unverified" radius={[4, 4, 0, 0]} />
+                    <Legend wrapperStyle={{ fontSize: '12px', color: colors.text }} />
+                    <Bar dataKey="verified" fill={colors.bar1} name="Verified (kWh)" radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="unverified" fill={colors.bar2} name="Unverified (kWh)" radius={[4, 4, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
@@ -313,24 +314,14 @@ export default function DashboardPage() {
         </div>
       </section>
 
-      {/* ------------------------------------------------------------------ */}
-      {/* Recent readings table                                                */}
-      {/* ------------------------------------------------------------------ */}
+      {/* Recent readings table */}
       <section aria-labelledby="readings-heading">
-        <h2
-          id="readings-heading"
-          className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100"
-        >
+        <h2 id="readings-heading" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
           Recent readings
         </h2>
-
         {readingsError && (
-          <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-            Failed to load readings.
-          </p>
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">Failed to load readings.</p>
         )}
-
-        {/* Responsive table wrapper — prevents horizontal scroll on mobile */}
         <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-800">
           <div className="overflow-x-auto">
             <table
@@ -340,64 +331,24 @@ export default function DashboardPage() {
             >
               <thead>
                 <tr className="bg-gray-50 dark:bg-gray-800/50">
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-                  >
-                    Meter ID
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-                  >
-                    kWh
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-                  >
-                    Timestamp
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-                  >
-                    Status
-                  </th>
+                  {['Meter ID', 'kWh', 'Timestamp', 'Status'].map((h) => (
+                    <th key={h} scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      {h}
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
                 {readingsLoading ? (
-                  <>
-                    <TableRowSkeleton cols={4} />
-                    <TableRowSkeleton cols={4} />
-                    <TableRowSkeleton cols={4} />
-                    <TableRowSkeleton cols={4} />
-                    <TableRowSkeleton cols={4} />
-                  </>
+                  <><TableRowSkeleton cols={4} /><TableRowSkeleton cols={4} /><TableRowSkeleton cols={4} /><TableRowSkeleton cols={4} /><TableRowSkeleton cols={4} /></>
                 ) : readings && readings.length > 0 ? (
                   readings.slice(0, 20).map((r) => (
-                    <tr
-                      key={r.id}
-                      className="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/40"
-                    >
-                      <td className="px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
-                        {r.meter_id}
-                      </td>
-                      <td className="px-4 py-3 text-gray-900 dark:text-gray-100">
-                        {r.kwh}
-                      </td>
-                      <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
-                        {new Date(r.timestamp).toLocaleString()}
-                      </td>
+                    <tr key={r.id} className="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/40">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">{r.meter_id}</td>
+                      <td className="px-4 py-3 text-gray-900 dark:text-gray-100">{r.kwh}</td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-gray-400">{new Date(r.timestamp).toLocaleString()}</td>
                       <td className="px-4 py-3">
-                        <span
-                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                            r.verified
-                              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                              : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-                          }`}
-                        >
+                        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${r.verified ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'}`}>
                           {r.verified ? 'Verified' : 'Pending'}
                         </span>
                       </td>
@@ -405,12 +356,7 @@ export default function DashboardPage() {
                   ))
                 ) : (
                   <tr>
-                    <td
-                      colSpan={4}
-                      className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400"
-                    >
-                      No readings found.
-                    </td>
+                    <td colSpan={4} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No readings found.</td>
                   </tr>
                 )}
               </tbody>

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -3,13 +3,17 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
 import { useState } from 'react'
+import { ToastProvider, ToastContainer } from '@/components/toast'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [qc] = useState(() => new QueryClient())
   return (
     <QueryClientProvider client={qc}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="solarproof-theme">
-        {children}
+        <ToastProvider>
+          {children}
+          <ToastContainer />
+        </ToastProvider>
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Sun, Moon, Menu, X } from 'lucide-react'
+import { Sun, Moon, Menu, X, Wallet, LogOut } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useEffect, useRef, useState } from 'react'
+import { useWallet } from '@/hooks/useWallet'
 
 const links = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -20,6 +21,7 @@ export function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const { address, connected, loading: walletLoading, connect, disconnect } = useWallet()
 
   // Close menu on route change
   useEffect(() => {
@@ -112,8 +114,32 @@ export function Navbar() {
           })}
         </div>
 
-        {/* Right side: theme toggle + hamburger */}
+        {/* Right side: theme toggle + wallet + hamburger */}
         <div className="flex items-center gap-2">
+          {/* Wallet connect */}
+          {!walletLoading && (
+            connected && address ? (
+              <button
+                onClick={disconnect}
+                title={address}
+                aria-label={`Disconnect wallet ${address.slice(0, 6)}…`}
+                className="hidden items-center gap-1.5 rounded-md border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 md:flex"
+              >
+                <Wallet className="h-3.5 w-3.5" aria-hidden="true" />
+                {address.slice(0, 4)}…{address.slice(-4)}
+                <LogOut className="h-3 w-3 ml-0.5 text-gray-400" aria-hidden="true" />
+              </button>
+            ) : (
+              <button
+                onClick={() => connect().catch(() => {})}
+                aria-label="Connect Freighter wallet"
+                className="hidden items-center gap-1.5 rounded-md bg-yellow-400 px-3 py-1.5 text-xs font-medium text-gray-900 transition-colors hover:bg-yellow-500 md:flex"
+              >
+                <Wallet className="h-3.5 w-3.5" aria-hidden="true" />
+                Connect wallet
+              </button>
+            )
+          )}
           {/* Dark mode toggle */}
           <button
             onClick={toggleTheme}

--- a/apps/web/src/components/retire-modal.tsx
+++ b/apps/web/src/components/retire-modal.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { X, Leaf } from 'lucide-react'
+
+interface Props {
+  certificateId: string
+  kwh: number
+  onConfirm: (reason: string) => Promise<void>
+  onClose: () => void
+}
+
+export function RetireModal({ certificateId, kwh, onConfirm, onClose }: Props) {
+  const [reason, setReason] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    try {
+      await onConfirm(reason)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="retire-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Leaf className="h-5 w-5 text-green-500" aria-hidden="true" />
+            <h2 id="retire-title" className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              Retire certificate
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+          You are about to permanently retire certificate{' '}
+          <span className="font-mono text-xs">{certificateId.slice(0, 8)}…</span> ({kwh} kWh).
+          This action cannot be undone.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="retire-reason"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Retirement reason <span className="text-gray-400">(optional)</span>
+            </label>
+            <textarea
+              id="retire-reason"
+              ref={inputRef}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              placeholder="e.g. Offset Q1 2026 carbon footprint"
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-yellow-400 focus:outline-none focus:ring-1 focus:ring-yellow-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
+            />
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-60"
+            >
+              {submitting ? 'Retiring…' : 'Confirm retirement'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { createContext, useCallback, useContext, useReducer, useRef } from 'react'
+
+export type ToastVariant = 'success' | 'error' | 'pending'
+
+export interface Toast {
+  id: string
+  variant: ToastVariant
+  message: string
+}
+
+type Action =
+  | { type: 'ADD'; toast: Toast }
+  | { type: 'REMOVE'; id: string }
+
+function reducer(state: Toast[], action: Action): Toast[] {
+  switch (action.type) {
+    case 'ADD':
+      return [...state, action.toast]
+    case 'REMOVE':
+      return state.filter((t) => t.id !== action.id)
+  }
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  toast: (variant: ToastVariant, message: string) => string
+  dismiss: (id: string) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, dispatch] = useReducer(reducer, [])
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: string) => {
+    clearTimeout(timers.current.get(id))
+    timers.current.delete(id)
+    dispatch({ type: 'REMOVE', id })
+  }, [])
+
+  const toast = useCallback(
+    (variant: ToastVariant, message: string) => {
+      const id = crypto.randomUUID()
+      dispatch({ type: 'ADD', toast: { id, variant, message } })
+      if (variant !== 'pending') {
+        timers.current.set(id, setTimeout(() => dismiss(id), 5000))
+      }
+      return id
+    },
+    [dismiss]
+  )
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast, dismiss }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider')
+  return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Toast UI
+// ---------------------------------------------------------------------------
+import { CheckCircle, XCircle, Loader2, X } from 'lucide-react'
+
+const icons: Record<ToastVariant, React.ElementType> = {
+  success: CheckCircle,
+  error: XCircle,
+  pending: Loader2,
+}
+
+const styles: Record<ToastVariant, string> = {
+  success: 'border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200',
+  error: 'border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200',
+  pending: 'border-yellow-200 bg-yellow-50 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200',
+}
+
+export function ToastContainer() {
+  const { toasts, dismiss } = useToast()
+  if (toasts.length === 0) return null
+
+  return (
+    <div
+      aria-live="polite"
+      aria-label="Notifications"
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+    >
+      {toasts.map((t) => {
+        const Icon = icons[t.variant]
+        return (
+          <div
+            key={t.id}
+            role="status"
+            className={`flex max-w-sm items-start gap-3 rounded-lg border px-4 py-3 shadow-md ${styles[t.variant]}`}
+          >
+            <Icon
+              className={`mt-0.5 h-4 w-4 shrink-0 ${t.variant === 'pending' ? 'animate-spin' : ''}`}
+              aria-hidden="true"
+            />
+            <p className="flex-1 text-sm">{t.message}</p>
+            <button
+              onClick={() => dismiss(t.id)}
+              aria-label="Dismiss notification"
+              className="ml-1 shrink-0 opacity-60 hover:opacity-100"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useWallet.ts
+++ b/apps/web/src/hooks/useWallet.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'solarproof-wallet'
+
+interface WalletState {
+  address: string | null
+  connected: boolean
+}
+
+const initial: WalletState = { address: null, connected: false }
+
+function isFreighterAvailable(): boolean {
+  return typeof window !== 'undefined' && 'freighter' in window
+}
+
+export function useWallet() {
+  const [state, setState] = useState<WalletState>(initial)
+  const [loading, setLoading] = useState(true)
+
+  // Restore persisted state on mount and verify the wallet is still authorised
+  useEffect(() => {
+    async function restore() {
+      try {
+        const stored = sessionStorage.getItem(STORAGE_KEY)
+        if (!stored) return
+
+        const { address } = JSON.parse(stored) as WalletState
+        if (!address || !isFreighterAvailable()) return
+
+        // Re-check authorisation without prompting the user
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const freighter = (window as any).freighter
+        const isAllowed: boolean = await freighter.isAllowed()
+        if (isAllowed) {
+          setState({ address, connected: true })
+        } else {
+          sessionStorage.removeItem(STORAGE_KEY)
+        }
+      } catch {
+        sessionStorage.removeItem(STORAGE_KEY)
+      } finally {
+        setLoading(false)
+      }
+    }
+    restore()
+  }, [])
+
+  const connect = useCallback(async () => {
+    if (!isFreighterAvailable()) {
+      throw new Error('Freighter wallet extension not found. Please install it.')
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const freighter = (window as any).freighter
+    await freighter.requestAccess()
+    const address: string = await freighter.getPublicKey()
+    const next: WalletState = { address, connected: true }
+    setState(next)
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    return address
+  }, [])
+
+  const disconnect = useCallback(() => {
+    setState(initial)
+    sessionStorage.removeItem(STORAGE_KEY)
+  }, [])
+
+  return { ...state, loading, connect, disconnect }
+}


### PR DESCRIPTION
Four independent features landed in one branch, one commit per issue.                                         
                                                                                                                
  Changes                                                                                                       
                                                                                                                
closes #11  — Freighter wallet connection state persists on page refresh                                         
                                                                                                                
  - New useWallet hook (src/hooks/useWallet.ts) stores { address } in sessionStorage on connect.                
  - On mount it calls freighter.isAllowed() silently — restores state if still authorised, clears storage if    
  not. No duplicate prompts.                                                                                    
  - disconnect() wipes all stored state.                                                                        
  - Wallet connect/disconnect button added to the Navbar (desktop).                                             
                                                                                                                
 closes #12  — Toast notification system                                                                         
                                                                                                                
  - ToastProvider + useToast hook (src/components/toast.tsx) — success, error, pending variants.                
  - ToastContainer renders an accessible aria-live="polite" region bottom-right.                                
  - Success/error toasts auto-dismiss after 5 s; pending toasts stay until explicitly dismissed or replaced.    
  - Manually dismissible via ✕ button.                                                                          
  - Wired into Providers — available app-wide.                                                                  
                                                                                                                
closes #13  — Certificate retirement flow                                                                       
                                                                                                                
  - New /certificates page (src/app/certificates/page.tsx) — table of all certificates with Active/Retired      
  status badges.                                                                                                
  - RetireModal (src/components/retire-modal.tsx) — confirmation dialog with optional retirement reason field.  
  - Calls POST /api/certificates/[id]/retire → energy_token contract retire().                                  
  - Certificate row updates to "Retired" after confirmation via queryClient.invalidateQueries.                  
  - Pending → success/error toasts via useToast. Retire button disabled when wallet not connected.              
  - New GET /api/certificates list endpoint (src/app/api/certificates/route.ts).                                
                                                                                                                
closes #14  — Energy generation charts                                                                          
                                                                                                                
  - Dashboard area chart gains a daily / weekly / monthly period selector (radio group, keyboard accessible).   
  - Per-meter bar chart now shows kWh (verified vs unverified) instead of reading counts.                       
  - Colour palette updated to amber + sky blue — WCAG AA contrast, colour-blind safe.                           
  - CSV export button on both charts (client-side Blob download, no server round-trip).  