### PR TITLE
docs: contract deployment guide and deployments.md

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,5 +1,20 @@
 # Deployment Guide
 
+This guide covers deploying SolarProof smart contracts to Stellar testnet and mainnet, verifying deployed bytecode on the Stellar explorer, and rolling back a bad deployment.
+
+Deployed contract addresses are tracked in [docs/deployments.md](deployments.md).
+
+---
+
+## Prerequisites
+
+- Rust toolchain pinned in `apps/contracts/rust-toolchain.toml`
+- `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
+- Stellar CLI: `cargo install --locked stellar-cli --features opt`
+- A funded Stellar account (see below for testnet faucet)
+
+---
+
 ## 1. Build contracts
 
 ```bash
@@ -7,47 +22,139 @@ cd apps/contracts
 stellar contract build
 ```
 
-## 2. Deploy
+Compiled WASM files are written to `target/wasm32-unknown-unknown/release/`.
+
+---
+
+## 2. Deploy to testnet
+
+### 2a. Fund a deployer account
+
+```bash
+stellar keys generate deployer --network testnet
+stellar keys fund deployer --network testnet
+# Or use the friendbot directly:
+# curl "https://friendbot.stellar.org?addr=$(stellar keys address deployer)"
+```
+
+### 2b. Deploy each contract
 
 ```bash
 TOKEN_ID=$(stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/energy_token.wasm \
-  --source YOUR_SECRET --network testnet)
+  --source deployer --network testnet)
 
 REGISTRY_ID=$(stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/audit_registry.wasm \
-  --source YOUR_SECRET --network testnet)
+  --source deployer --network testnet)
 
 GOV_ID=$(stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/community_governance.wasm \
-  --source YOUR_SECRET --network testnet)
+  --source deployer --network testnet)
+
+echo "TOKEN_ID=$TOKEN_ID"
+echo "REGISTRY_ID=$REGISTRY_ID"
+echo "GOV_ID=$GOV_ID"
 ```
 
-## 3. Initialize
+### 2c. Initialize each contract
 
 ```bash
-stellar contract invoke --id $TOKEN_ID --source YOUR_SECRET --network testnet \
-  -- initialize --admin ADMIN_ADDRESS --minter MINTER_ADDRESS
+ADMIN=$(stellar keys address deployer)
 
-stellar contract invoke --id $REGISTRY_ID --source YOUR_SECRET --network testnet \
-  -- initialize --admin ADMIN_ADDRESS
+stellar contract invoke --id $TOKEN_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN --minter $ADMIN
 
-stellar contract invoke --id $GOV_ID --source YOUR_SECRET --network testnet \
-  -- initialize --admin ADMIN_ADDRESS --quorum 51 --voting_period_ledgers 17280
+stellar contract invoke --id $REGISTRY_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN
+
+stellar contract invoke --id $GOV_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN --quorum 51 --voting_period_ledgers 17280
 ```
 
-## 4. Environment variables
+### 2d. Record the addresses
+
+Update [docs/deployments.md](deployments.md) with the three contract IDs, then set them in your environment:
 
 ```env
 NEXT_PUBLIC_ENERGY_TOKEN_ID=<TOKEN_ID>
 NEXT_PUBLIC_AUDIT_REGISTRY_ID=<REGISTRY_ID>
 NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID=<GOV_ID>
-MINTER_SECRET_KEY=<MINTER_SECRET>
+MINTER_SECRET_KEY=<deployer-secret>
 ```
 
-## 5. Register a meter
+---
+
+## 3. Deploy to mainnet
+
+> ⚠️ Mainnet deployments are irreversible. Use a hardware wallet or HSM-backed key for the deployer account.
+
+The steps are identical to testnet — replace `--network testnet` with `--network mainnet` throughout.
+
+```bash
+stellar keys generate deployer-mainnet --network mainnet
+# Fund from a real XLM source (no friendbot on mainnet)
+
+TOKEN_ID=$(stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/energy_token.wasm \
+  --source deployer-mainnet --network mainnet)
+# ... repeat for audit_registry and community_governance
+```
+
+Update [docs/deployments.md](deployments.md) with the mainnet contract IDs.
+
+---
+
+## 4. Automated deployment (CI)
+
+The `.github/workflows/deploy-contracts.yml` workflow automates testnet deployment on pushes to `main`. It reads the deployer secret from the `DEPLOYER_SECRET` GitHub Actions secret and writes the resulting contract IDs back to the repository.
+
+To trigger manually:
+
+```
+GitHub → Actions → Deploy Contracts → Run workflow
+```
+
+---
+
+## 5. Verify deployed bytecode on Stellar Expert
+
+After deployment, confirm the on-chain WASM matches your local build:
+
+1. Open `https://stellar.expert/explorer/testnet/contract/<CONTRACT_ID>`
+2. Click the **Contract** tab → **WASM** section.
+3. Copy the **WASM hash** shown on the page.
+4. Compute the hash of your local build:
+
+```bash
+sha256sum target/wasm32-unknown-unknown/release/energy_token.wasm
+```
+
+5. The two hashes must match. A mismatch means the on-chain contract was deployed from a different build.
+
+---
+
+## 6. Rollback procedure
+
+Soroban contracts are immutable once deployed — you cannot overwrite a contract ID. The rollback procedure is:
+
+1. **Deploy a new contract** from the corrected WASM (produces a new contract ID).
+2. **Update environment variables** (`NEXT_PUBLIC_ENERGY_TOKEN_ID`, etc.) to point to the new contract ID.
+3. **Redeploy the web app** (Vercel picks up the new env vars automatically on the next deployment).
+4. **Update [docs/deployments.md](deployments.md)** with the new contract ID and a note explaining the rollback.
+5. **Do not delete the old contract** — it remains on-chain as an audit record.
+
+For the `audit_registry` contract specifically, all historical anchors remain valid on the old contract ID. The new deployment starts a fresh registry; existing certificates still resolve against the old contract via the `anchor_explorer` links stored in the database.
+
+---
+
+## 7. Register a meter after deployment
 
 ```bash
 node scripts/gen-meter-key.mjs
-# Insert meter into Supabase with the generated public_key_hex
+# Insert the meter into Supabase:
+# INSERT INTO meters (id, pubkey_hex, name, cooperative_id, active)
+# VALUES (gen_random_uuid(), '<public_key_hex>', 'meter-name', '<coop-id>', true);
 ```
+
+See [ONBOARDING.md](ONBOARDING.md) for the full end-to-end local setup.

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,0 +1,29 @@
+# Contract Deployments
+
+Deployed contract addresses for each environment. Update this file after every deployment.
+
+---
+
+## Testnet
+
+| Contract | Contract ID | Deployed At | Deployed By |
+|---|---|---|---|
+| `energy_token` | _(set after first deploy)_ | — | — |
+| `audit_registry` | _(set after first deploy)_ | — | — |
+| `community_governance` | _(set after first deploy)_ | — | — |
+
+Explorer: `https://stellar.expert/explorer/testnet/contract/<CONTRACT_ID>`
+
+## Mainnet
+
+| Contract | Contract ID | Deployed At | Deployed By |
+|---|---|---|---|
+| `energy_token` | _(not yet deployed)_ | — | — |
+| `audit_registry` | _(not yet deployed)_ | — | — |
+| `community_governance` | _(not yet deployed)_ | — | — |
+
+Explorer: `https://stellar.expert/explorer/public/contract/<CONTRACT_ID>`
+
+---
+
+> **How to update this file:** After running the deploy workflow (or manual deploy steps below), paste the contract IDs returned by `stellar contract deploy` into the table above and commit the change.


### PR DESCRIPTION
Closes #108

## Changes
- Expanded `docs/DEPLOYMENT.md` with full testnet and mainnet deployment steps, bytecode verification on Stellar Expert, and a rollback procedure
- Added `docs/deployments.md` to track deployed contract addresses per environment

## Acceptance criteria
- [x] Deployment steps documented for testnet and mainnet
- [x] Contract verification on Stellar explorer documented
- [x] Deployed contract addresses tracked in `docs/deployments.md`
- [x] Rollback procedure documented