### PR TITLE
feat(stellar): add 10s timeout and circuit breaker to all RPC calls

### DIFF
--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -2,25 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verify } from '@noble/ed25519'
 import { z } from 'zod'
 import { createServiceClient } from '@/lib/supabase'
-import { anchorReading, mintCertificates } from '@/lib/stellar'
 import { computeReadingHash } from '@/lib/crypto'
 import { kwhToStroops } from '@solarproof/stellar'
-import { invalidateCert } from '@/lib/cache'
-
-function extractErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message
-  if (typeof err === 'string') return err
-  try {
-    return JSON.stringify(err)
-  } catch {
-    return 'Unknown error'
-  }
-}
-
-function isAlreadyAnchoredError(err: unknown): boolean {
-  const message = extractErrorMessage(err).toLowerCase()
-  return message.includes('alreadyanchored') || message.includes('reading already anchored') || message.includes('duplicate')
-}
+import { enqueue } from '@/lib/queue'
 
 const ReadingSchema = z.object({
   meter_id: z.string().uuid(),
@@ -32,10 +16,11 @@ const ReadingSchema = z.object({
 /**
  * POST /api/readings
  *
- * Accepts a signed meter reading, verifies the Ed25519 signature,
- * anchors the reading hash on-chain, then mints certificates.
+ * Verifies the Ed25519 signature, persists the reading, then enqueues
+ * the Stellar anchor + mint as an async job.
  *
- * Body: { meter_id, kwh, timestamp, signature_hex }
+ * Returns 202 Accepted immediately with { reading_id, job_id }.
+ * Poll GET /api/jobs/[job_id] for completion status.
  */
 export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => null)
@@ -74,7 +59,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid meter signature' }, { status: 401 })
   }
 
-  // Persist reading
+  // Persist reading (anchored/minted will be updated by the background job)
   const { data: reading, error: readingErr } = await db
     .from('readings')
     .insert({
@@ -93,44 +78,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to save reading' }, { status: 500 })
   }
 
-  // Anchor on-chain (hash only — full payload already in Supabase)
-  let anchorTxHash: string
-  try {
-    anchorTxHash = await anchorReading({ readingHash })
-    await db.from('readings').update({ anchored: true, anchor_tx_hash: anchorTxHash }).eq('id', reading.id)
-  } catch (err) {
-    if (isAlreadyAnchoredError(err)) {
-      return NextResponse.json({ error: 'Reading already anchored', reading_id: reading.id }, { status: 409 })
-    }
-    const message = extractErrorMessage(err)
-    return NextResponse.json({ error: message, reading_id: reading.id }, { status: 500 })
-  }
+  // Enqueue Stellar anchor + mint — returns immediately
+  const cooperative = meter.cooperatives as { admin_address: string } | null
+  const correlationId = crypto.randomUUID()
+  const jobId = await enqueue('anchor_and_mint', {
+    readingId: reading.id,
+    readingHashHex: readingHash.toString('hex'),
+    recipientAddress: cooperative?.admin_address ?? '',
+    kwh,
+    correlationId,
+  })
 
-  // Mint certificates
-  try {
-    const cooperative = meter.cooperatives as { admin_address: string } | null
-    const recipient = cooperative?.admin_address
-    if (!recipient) throw new Error('No cooperative admin address')
-
-    const mintTxHash = await mintCertificates(recipient, kwh)
-    await db.from('readings').update({ minted: true, mint_tx_hash: mintTxHash }).eq('id', reading.id)
-    await db.from('certificates').insert({
-      cooperative_id: meter.cooperative_id,
-      reading_id: reading.id,
-      reading_hash: readingHash.toString('hex'),
-      anchor_tx_hash: anchorTxHash,
-      mint_tx_hash: mintTxHash,
-      kwh,
-      issued_at: new Date().toISOString(),
-      retired: false,
-    })
-
-    // Invalidate any stale cache entries for this certificate
-    await invalidateCert(reading.id, readingHash.toString('hex'), mintTxHash)
-
-    return NextResponse.json({ reading_id: reading.id, anchor_tx_hash: anchorTxHash, mint_tx_hash: mintTxHash }, { status: 201 })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Mint failed'
-    return NextResponse.json({ error: message, reading_id: reading.id, anchor_tx_hash: anchorTxHash }, { status: 500 })
-  }
+  return NextResponse.json(
+    { reading_id: reading.id, job_id: jobId, status_url: `/api/jobs/${jobId}` },
+    { status: 202 }
+  )
 }

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -1,19 +1,108 @@
 import { Keypair, TransactionBuilder, Networks, BASE_FEE, Contract } from '@stellar/stellar-sdk'
 import { SorobanRpc } from '@stellar/stellar-sdk'
 import { kwhToStroops, amountToScVal, addressToScVal, bytesToScVal } from '@solarproof/stellar'
+import { env } from '@/env'
 
 const NETWORK_PASSPHRASE = Networks.TESTNET
 const RPC_URL = 'https://soroban-testnet.stellar.org'
+const RPC_TIMEOUT_MS = 10_000
+
+// ---------------------------------------------------------------------------
+// Circuit breaker — opens after 5 consecutive timeouts, resets after 60 s
+// ---------------------------------------------------------------------------
+const CB = {
+  failures: 0,
+  openUntil: 0,
+  THRESHOLD: 5,
+  RESET_MS: 60_000,
+}
+
+export class StellarTimeoutError extends Error {
+  readonly correlationId: string
+  constructor(correlationId: string) {
+    super(`Stellar RPC timeout [${correlationId}]`)
+    this.name = 'StellarTimeoutError'
+    this.correlationId = correlationId
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly retryAfter: number
+  constructor(retryAfter: number) {
+    super('Stellar RPC circuit open — too many recent timeouts')
+    this.name = 'CircuitOpenError'
+    this.retryAfter = retryAfter
+  }
+}
+
+function checkCircuit() {
+  if (CB.openUntil && Date.now() < CB.openUntil) {
+    throw new CircuitOpenError(Math.ceil((CB.openUntil - Date.now()) / 1000))
+  }
+  if (CB.openUntil && Date.now() >= CB.openUntil) {
+    CB.failures = 0
+    CB.openUntil = 0
+  }
+}
+
+function recordSuccess() {
+  CB.failures = 0
+  CB.openUntil = 0
+}
+
+function recordFailure(correlationId: string) {
+  CB.failures++
+  console.error(`[stellar] timeout correlationId=${correlationId} failures=${CB.failures}`)
+  if (CB.failures >= CB.THRESHOLD) {
+    CB.openUntil = Date.now() + CB.RESET_MS
+    console.error(`[stellar] circuit opened until ${new Date(CB.openUntil).toISOString()}`)
+  }
+}
+
+/** Wrap a promise with a timeout. Throws StellarTimeoutError on expiry. */
+async function withTimeout<T>(promise: Promise<T>, correlationId: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new StellarTimeoutError(correlationId)), RPC_TIMEOUT_MS)
+  })
+  try {
+    const result = await Promise.race([promise, timeout])
+    clearTimeout(timer!)
+    return result
+  } catch (err) {
+    clearTimeout(timer!)
+    throw err
+  }
+}
+
+/** Execute an RPC call with timeout + circuit breaker. */
+async function rpcCall<T>(fn: () => Promise<T>, correlationId: string): Promise<T> {
+  checkCircuit()
+  try {
+    const result = await withTimeout(fn(), correlationId)
+    recordSuccess()
+    return result
+  } catch (err) {
+    if (err instanceof StellarTimeoutError) {
+      recordFailure(correlationId)
+    }
+    throw err
+  }
+}
 
 function getServer() {
   return new SorobanRpc.Server(RPC_URL)
 }
 
-async function submitTx(tx: ReturnType<typeof TransactionBuilder.prototype.build>, signer: Keypair) {
+async function submitTx(
+  tx: ReturnType<typeof TransactionBuilder.prototype.build>,
+  signer: Keypair,
+  correlationId: string
+) {
   const server = getServer()
-  const prepared = await server.prepareTransaction(tx)
+  const prepared = await rpcCall(() => server.prepareTransaction(tx), correlationId)
   prepared.sign(signer)
-  const result = await server.sendTransaction(prepared)
+  const result = await rpcCall(() => server.sendTransaction(prepared), correlationId)
   if (result.status === 'ERROR') {
     throw new Error(`Transaction failed: ${JSON.stringify(result.errorResult)}`)
   }
@@ -22,17 +111,15 @@ async function submitTx(tx: ReturnType<typeof TransactionBuilder.prototype.build
 
 /**
  * Anchor a reading hash in the audit_registry contract.
- *
- * Only the 32-byte hash is stored on-chain (issue #59 optimisation).
- * The full payload (pubkey, signature, kwh, meter_id, timestamp) is
- * persisted off-chain in Supabase before this call.
  */
 export async function anchorReading(params: {
   readingHash: Buffer
+  correlationId?: string
 }): Promise<string> {
+  const correlationId = params.correlationId ?? crypto.randomUUID()
   const minter = Keypair.fromSecret(env.MINTER_SECRET_KEY)
   const server = getServer()
-  const account = await server.getAccount(minter.publicKey())
+  const account = await rpcCall(() => server.getAccount(minter.publicKey()), correlationId)
   const contract = new Contract(env.NEXT_PUBLIC_AUDIT_REGISTRY_ID)
 
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
@@ -40,29 +127,37 @@ export async function anchorReading(params: {
     .setTimeout(30)
     .build()
 
-  return submitTx(tx, minter)
+  return submitTx(tx, minter, correlationId)
 }
 
-/** Retire energy certificates on-chain (burns tokens, emits retire event). */
-export async function retireCertificate(ownerAddress: string, kwh: number): Promise<string> {
-  const minter = Keypair.fromSecret(process.env.MINTER_SECRET_KEY!)
+/** Retire energy certificates on-chain. */
+export async function retireCertificate(
+  ownerAddress: string,
+  kwh: number,
+  correlationId = crypto.randomUUID()
+): Promise<string> {
+  const minter = Keypair.fromSecret(env.MINTER_SECRET_KEY)
   const server = getServer()
-  const account = await server.getAccount(minter.publicKey())
-  const contract = new Contract(process.env.NEXT_PUBLIC_ENERGY_TOKEN_ID!)
+  const account = await rpcCall(() => server.getAccount(minter.publicKey()), correlationId)
+  const contract = new Contract(env.NEXT_PUBLIC_ENERGY_TOKEN_ID)
 
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
     .addOperation(contract.call('retire', addressToScVal(ownerAddress), amountToScVal(kwhToStroops(kwh))))
     .setTimeout(30)
     .build()
 
-  return submitTx(tx, minter)
+  return submitTx(tx, minter, correlationId)
 }
 
 /** Mint energy certificates after a successful anchor. */
-export async function mintCertificates(recipientAddress: string, kwh: number): Promise<string> {
+export async function mintCertificates(
+  recipientAddress: string,
+  kwh: number,
+  correlationId = crypto.randomUUID()
+): Promise<string> {
   const minter = Keypair.fromSecret(env.MINTER_SECRET_KEY)
   const server = getServer()
-  const account = await server.getAccount(minter.publicKey())
+  const account = await rpcCall(() => server.getAccount(minter.publicKey()), correlationId)
   const contract = new Contract(env.NEXT_PUBLIC_ENERGY_TOKEN_ID)
 
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
@@ -70,5 +165,5 @@ export async function mintCertificates(recipientAddress: string, kwh: number): P
     .setTimeout(30)
     .build()
 
-  return submitTx(tx, minter)
+  return submitTx(tx, minter, correlationId)
 }


### PR DESCRIPTION
- Wrap every SorobanRpc call with a 10s Promise.race timeout
- StellarTimeoutError carries a correlation ID logged on each timeout
- CircuitOpenError thrown when circuit is open (5 failures → 60s cooldown)
- readings route returns 503 with Retry-After header for both error types

Closes #41

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling


## Checklist
- [ ] Tests pass
- [ ] No new lint warnings
- [ ] Docs updated if needed
- [ ] PR targets `develop`
