### PR TITLE
feat(queue): async Stellar transaction queue with job status API

### DIFF
--- a/apps/web/src/app/api/jobs/[id]/route.ts
+++ b/apps/web/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+
+/** GET /api/jobs/[id] — query job status */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const db = createServiceClient()
+
+  const { data, error } = await db
+    .from('jobs')
+    .select('id, type, status, attempts, result, error, created_at, updated_at')
+    .eq('id', id)
+    .single()
+
+  if (error || !data) return NextResponse.json({ error: 'Job not found' }, { status: 404 })
+  return NextResponse.json(data)
+}

--- a/apps/web/src/lib/database.types.ts
+++ b/apps/web/src/lib/database.types.ts
@@ -36,6 +36,16 @@ export interface Database {
         Insert: Omit<Database['public']['Tables']['certificates']['Row'], 'id'>
         Update: Partial<Database['public']['Tables']['certificates']['Insert']>
       }
+      jobs: {
+        Row: {
+          id: string; type: string; payload: Record<string, unknown>
+          status: 'pending' | 'running' | 'done' | 'failed'
+          attempts: number; result: Record<string, unknown> | null
+          error: string | null; created_at: string; updated_at: string
+        }
+        Insert: Omit<Database['public']['Tables']['jobs']['Row'], 'id' | 'created_at' | 'updated_at'>
+        Update: Partial<Database['public']['Tables']['jobs']['Insert']>
+      }
     }
     Views: Record<string, never>
     Functions: Record<string, never>

--- a/apps/web/src/lib/queue.ts
+++ b/apps/web/src/lib/queue.ts
@@ -1,0 +1,126 @@
+/**
+ * Lightweight async job queue backed by Supabase.
+ *
+ * Usage:
+ *   const jobId = await enqueue('anchor_and_mint', { readingId, ... })
+ *   // returns immediately; worker processes in background
+ */
+import { createServiceClient } from '@/lib/supabase'
+
+export type JobType = 'anchor_and_mint'
+export type JobStatus = 'pending' | 'running' | 'done' | 'failed'
+
+const MAX_ATTEMPTS = 3
+
+/** Enqueue a job and return its ID. */
+export async function enqueue(type: JobType, payload: Record<string, unknown>): Promise<string> {
+  const db = createServiceClient()
+  const { data, error } = await db
+    .from('jobs')
+    .insert({ type, payload, status: 'pending', attempts: 0 })
+    .select('id')
+    .single()
+
+  if (error || !data) throw new Error(`Failed to enqueue job: ${error?.message}`)
+
+  // Fire-and-forget: process in background without blocking the response
+  processJob(data.id).catch((err) =>
+    console.error(`[queue] background processing error job=${data.id}`, err)
+  )
+
+  return data.id
+}
+
+/** Process a single job by ID. Retries up to MAX_ATTEMPTS on failure. */
+export async function processJob(jobId: string): Promise<void> {
+  const db = createServiceClient()
+
+  const { data: job } = await db
+    .from('jobs')
+    .select('*')
+    .eq('id', jobId)
+    .single()
+
+  if (!job || job.status === 'done') return
+
+  const attempts = job.attempts + 1
+  await db.from('jobs').update({ status: 'running', attempts }).eq('id', jobId)
+
+  try {
+    const result = await runJob(job.type as JobType, job.payload as Record<string, unknown>)
+    await db.from('jobs').update({ status: 'done', result }).eq('id', jobId)
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    if (attempts < MAX_ATTEMPTS) {
+      // Exponential back-off: 2s, 4s, 8s
+      const delay = 2 ** attempts * 1000
+      await db.from('jobs').update({ status: 'pending', error }).eq('id', jobId)
+      setTimeout(() => processJob(jobId).catch(console.error), delay)
+    } else {
+      await db.from('jobs').update({ status: 'failed', error }).eq('id', jobId)
+    }
+  }
+}
+
+/** Dispatch to the correct handler based on job type. */
+async function runJob(
+  type: JobType,
+  payload: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  switch (type) {
+    case 'anchor_and_mint':
+      return runAnchorAndMint(payload)
+    default:
+      throw new Error(`Unknown job type: ${type}`)
+  }
+}
+
+async function runAnchorAndMint(
+  payload: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  // Lazy import to avoid circular deps
+  const { anchorReading, mintCertificates } = await import('@/lib/stellar')
+  const { createServiceClient: svc } = await import('@/lib/supabase')
+  const { invalidateCert } = await import('@/lib/cache')
+
+  const { readingId, readingHashHex, recipientAddress, kwh, correlationId } = payload as {
+    readingId: string
+    readingHashHex: string
+    recipientAddress: string
+    kwh: number
+    correlationId: string
+  }
+
+  const db = svc()
+  const readingHash = Buffer.from(readingHashHex, 'hex')
+
+  const anchorTxHash = await anchorReading({ readingHash, correlationId })
+  await db.from('readings').update({ anchored: true, anchor_tx_hash: anchorTxHash }).eq('id', readingId)
+
+  const mintTxHash = await mintCertificates(recipientAddress, kwh, correlationId)
+  await db.from('readings').update({ minted: true, mint_tx_hash: mintTxHash }).eq('id', readingId)
+
+  // Fetch cooperative_id for certificate insert
+  const { data: reading } = await db
+    .from('readings')
+    .select('meter_id, meters(cooperative_id)')
+    .eq('id', readingId)
+    .single()
+
+  const cooperativeId = (reading?.meters as { cooperative_id: string } | null)?.cooperative_id
+  if (cooperativeId) {
+    await db.from('certificates').insert({
+      cooperative_id: cooperativeId,
+      reading_id: readingId,
+      reading_hash: readingHashHex,
+      anchor_tx_hash: anchorTxHash,
+      mint_tx_hash: mintTxHash,
+      kwh,
+      issued_at: new Date().toISOString(),
+      retired: false,
+    })
+    await invalidateCert(readingId, readingHashHex, mintTxHash)
+  }
+
+  return { anchor_tx_hash: anchorTxHash, mint_tx_hash: mintTxHash }
+}

--- a/supabase/migrations/20240101000005_jobs.sql
+++ b/supabase/migrations/20240101000005_jobs.sql
@@ -1,0 +1,28 @@
+-- Migration 005: async job queue for Stellar transactions
+create table jobs (
+  id uuid primary key default gen_random_uuid(),
+  type text not null,                          -- e.g. 'anchor_and_mint'
+  payload jsonb not null default '{}',
+  status text not null default 'pending'       -- pending | running | done | failed
+    check (status in ('pending', 'running', 'done', 'failed')),
+  attempts int not null default 0,
+  result jsonb,
+  error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index jobs_status_created_at on jobs (status, created_at);
+
+-- Auto-update updated_at
+create or replace function set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger jobs_updated_at
+  before update on jobs
+  for each row execute procedure set_updated_at();


### PR DESCRIPTION
- Migration: jobs table (status, attempts, result, error, updated_at trigger)
- queue.ts: enqueue() + processJob() with 3-attempt exponential back-off
- GET /api/jobs/[id]: poll job status (pending|running|done|failed)
- POST /api/readings now returns 202 Accepted with {reading_id, job_id, status_url}
- Stellar anchor+mint runs in background; readings route no longer blocks on RPC

Closes #42

## Summary

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling


## Checklist
- [ ] Tests pass
- [ ] No new lint warnings
- [ ] Docs updated if needed
- [ ] PR targets `develop`
