### PR TITLE
feat(api): implement idempotency for meter reading submissions

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -22,11 +22,14 @@ function isAlreadyAnchoredError(err: unknown): boolean {
   return message.includes('alreadyanchored') || message.includes('reading already anchored') || message.includes('duplicate')
 }
 
+const NONCE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
 const ReadingSchema = z.object({
   meter_id: z.string().uuid(),
   kwh: z.number().positive(),
   timestamp: z.number().int().positive(), // Unix seconds
   signature_hex: z.string().length(128),  // 64-byte Ed25519 sig as hex
+  nonce: z.string().min(1).max(128).optional(),
 })
 
 /**
@@ -44,8 +47,26 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   }
 
-  const { meter_id, kwh, timestamp, signature_hex } = parsed.data
+  const { meter_id, kwh, timestamp, signature_hex, nonce } = parsed.data
   const db = createServiceClient()
+
+  // Idempotency check: return cached response if nonce was seen within 24 h
+  if (nonce) {
+    const { data: existing } = await db
+      .from('idempotency_keys')
+      .select('response, created_at')
+      .eq('nonce', nonce)
+      .single()
+
+    if (existing) {
+      const age = Date.now() - new Date(existing.created_at).getTime()
+      if (age < NONCE_TTL_MS) {
+        return NextResponse.json(existing.response, { status: 200 })
+      }
+      // Expired — delete and allow re-processing
+      await db.from('idempotency_keys').delete().eq('nonce', nonce)
+    }
+  }
 
   // Fetch meter + cooperative
   const { data: meter } = await db
@@ -128,7 +149,14 @@ export async function POST(req: NextRequest) {
     // Invalidate any stale cache entries for this certificate
     await invalidateCert(reading.id, readingHash.toString('hex'), mintTxHash)
 
-    return NextResponse.json({ reading_id: reading.id, anchor_tx_hash: anchorTxHash, mint_tx_hash: mintTxHash }, { status: 201 })
+    const successResponse = { reading_id: reading.id, anchor_tx_hash: anchorTxHash, mint_tx_hash: mintTxHash }
+
+    // Persist nonce so retries within 24 h get the same response
+    if (nonce) {
+      await db.from('idempotency_keys').insert({ nonce, reading_id: reading.id, response: successResponse })
+    }
+
+    return NextResponse.json(successResponse, { status: 201 })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Mint failed'
     return NextResponse.json({ error: message, reading_id: reading.id, anchor_tx_hash: anchorTxHash }, { status: 500 })

--- a/apps/web/src/lib/database.types.ts
+++ b/apps/web/src/lib/database.types.ts
@@ -26,6 +26,13 @@ export interface Database {
         Insert: Omit<Database['public']['Tables']['readings']['Row'], 'id'>
         Update: Partial<Database['public']['Tables']['readings']['Insert']>
       }
+      idempotency_keys: {
+        Row: {
+          nonce: string; reading_id: string; response: Json; created_at: string
+        }
+        Insert: Omit<Database['public']['Tables']['idempotency_keys']['Row'], 'created_at'>
+        Update: Partial<Database['public']['Tables']['idempotency_keys']['Insert']>
+      }
       certificates: {
         Row: {
           id: string; cooperative_id: string; reading_id: string

--- a/supabase/migrations/20240101000005_idempotency_keys.sql
+++ b/supabase/migrations/20240101000005_idempotency_keys.sql
@@ -1,0 +1,13 @@
+-- Migration 005: idempotency keys for meter reading submissions
+-- Prevents duplicate anchoring when clients retry on network failure.
+-- Nonces expire after 24 hours (enforced by the application layer).
+
+create table idempotency_keys (
+  nonce       text        primary key,
+  reading_id  uuid        not null references readings(id) on delete cascade,
+  response    jsonb       not null,
+  created_at  timestamptz not null default now()
+);
+
+-- Allow the application to efficiently purge expired keys
+create index on idempotency_keys(created_at);


### PR DESCRIPTION
## Summary

Network retries can cause duplicate readings to be anchored on-chain. This PR adds idempotency support to `POST /api/readings` so clients can safely retry without causing duplicate anchors or mints.

## Changes

### `supabase/migrations/20240101000005_idempotency_keys.sql`
- New `idempotency_keys` table: `nonce` (PK), `reading_id` (FK → readings), `response` (jsonb), `created_at`
- Index on `created_at` for efficient TTL cleanup

### `apps/web/src/lib/database.types.ts`
- Added `idempotency_keys` table type (Row / Insert / Update)

### `apps/web/src/app/api/readings/route.ts`
- Added optional `nonce` field to `ReadingSchema` (1–128 chars)
- Before processing: if nonce exists and was seen within 24 h, return the cached `200` response immediately (no re-anchor, no re-mint)
- If nonce is expired (> 24 h), delete it and allow re-processing
- After a successful mint: persist `{ nonce, reading_id, response }` in `idempotency_keys`

### `apps/web/.eslintrc.json`
- Added missing ESLint config (`next/core-web-vitals` + `next/typescript`) — `pnpm lint` was failing without it

Closes #28 