### PR TITLE
feat(energy_token): implement retire() for REC compliance

### DIFF
--- a/apps/contracts/energy_token/src/lib.rs
+++ b/apps/contracts/energy_token/src/lib.rs
@@ -33,6 +33,8 @@ pub enum DataKey {
     Paused,
     /// Allowance: (from, spender) -> i128
     Allowance(Address, Address),
+    /// Retired: address -> bool
+    Retired(Address),
 }
 
 #[contract]
@@ -79,6 +81,7 @@ impl EnergyToken {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
         Self::require_not_paused(&env);
+        Self::require_not_retired(&env, &from);
         Self::move_balance(&env, &from, &to, amount);
         env.events()
             .publish((symbol_short!("transfer"),), (from, to, amount));
@@ -116,6 +119,7 @@ impl EnergyToken {
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
         Self::require_not_paused(&env);
+        Self::require_not_retired(&env, &from);
         Self::spend_allowance(&env, &from, &spender, amount);
         Self::move_balance(&env, &from, &to, amount);
         env.events()
@@ -176,6 +180,33 @@ impl EnergyToken {
         env.events().publish((symbol_short!("burn"),), (from, amount));
     }
 
+    /// Retire all tokens held by `from`, burning them permanently.
+    ///
+    /// # Authorization
+    /// Requires `from` authorisation.
+    pub fn retire(env: Env, from: Address, reason: String) {
+        from.require_auth();
+        Self::require_not_paused(&env);
+        assert!(
+            !env.storage()
+                .persistent()
+                .get::<_, bool>(&DataKey::Retired(from.clone()))
+                .unwrap_or(false),
+            "already retired"
+        );
+        let amount = Self::balance(env.clone(), from.clone());
+        assert!(amount > 0, "no balance to retire");
+        Self::deduct_balance(&env, &from, amount);
+        Self::add_burned(&env, amount);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Retired(from.clone()), &true);
+        env.events().publish(
+            (symbol_short!("retire"),),
+            (from, amount, reason, env.ledger().timestamp()),
+        );
+    }
+
     pub fn total_supply(env: Env) -> i128 {
         let minted: i128 = env
             .storage()
@@ -216,6 +247,15 @@ impl EnergyToken {
             .get(&DataKey::Paused)
             .unwrap_or(false);
         assert!(!paused, "contract is paused");
+    }
+
+    fn require_not_retired(env: &Env, account: &Address) {
+        let retired: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Retired(account.clone()))
+            .unwrap_or(false);
+        assert!(!retired, "token is retired");
     }
 
     fn move_balance(env: &Env, from: &Address, to: &Address, amount: i128) {
@@ -614,5 +654,50 @@ mod tests {
         let minter = Address::generate(&env);
         client.initialize(&admin, &minter);
         assert_eq!(client.admin(), admin);
+    }
+
+    // ── retire tests ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_retire_burns_balance_and_updates_supply() {
+        let (env, client) = setup();
+        let user = Address::generate(&env);
+        client.mint(&user, &1000_i128);
+        client.retire(&user, &String::from_str(&env, "REC compliance"));
+        assert_eq!(client.balance(&user), 0);
+        assert_eq!(client.total_supply(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "already retired")]
+    fn test_retire_double_retire_panics() {
+        let (env, client) = setup();
+        let user = Address::generate(&env);
+        client.mint(&user, &500_i128);
+        client.retire(&user, &String::from_str(&env, "first"));
+        // mint again so balance > 0, but retired flag is set
+        client.mint(&user, &100_i128);
+        client.retire(&user, &String::from_str(&env, "second"));
+    }
+
+    #[test]
+    #[should_panic(expected = "token is retired")]
+    fn test_transfer_from_retired_address_panics() {
+        let (env, client) = setup();
+        let user = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        client.mint(&user, &1000_i128);
+        client.retire(&user, &String::from_str(&env, "REC compliance"));
+        // mint again so balance > 0, but retired flag blocks transfer
+        client.mint(&user, &100_i128);
+        client.transfer(&user, &recipient, &100_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "no balance to retire")]
+    fn test_retire_zero_balance_panics() {
+        let (env, client) = setup();
+        let user = Address::generate(&env);
+        client.retire(&user, &String::from_str(&env, "empty"));
     }
 }


### PR DESCRIPTION
## Summary



Adds `retire()` to the `energy_token` contract so certificates can be permanently burned for REC compliance.

**What changed** (`energy_token/src/lib.rs`):

- `Retired(Address)` added to `DataKey` enum
- `retire(from, reason)`: requires auth, checks not already retired, burns full balance, sets the `Retired` flag, emits `(retire, from, amount, reason, timestamp)`
- `require_not_retired` helper guards `transfer()` and `transfer_from()` — retired addresses cannot move tokens
- 4 new tests: burns balance + updates supply, double-retire panics, transfer blocked after retire, zero-balance retire panics

Closes #54