### PR TITLE
docs(contracts): NatSpec-style doc comments for all public functions

### DIFF
--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -106,6 +106,7 @@ impl AuditRegistry {
         env.storage().instance().set(&DataKey::Version, &soroban_sdk::String::from_str(&env, VERSION));
     }
 
+    /// Returns the contract version string (e.g. `"1.0.0"`).
     pub fn get_version(env: Env) -> soroban_sdk::String {
         env.storage().instance()
             .get(&DataKey::Version)
@@ -113,6 +114,15 @@ impl AuditRegistry {
     }
 
     /// Migrate state schema to a new version. Admin-only.
+    ///
+    /// # Arguments
+    /// * `new_version` — version string to store (e.g. `"2.0.0"`).
+    ///
+    /// # Authorization
+    /// Requires `admin` authorisation.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
     pub fn migrate(env: Env, new_version: soroban_sdk::String) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
         admin.require_auth();
@@ -175,21 +185,27 @@ impl AuditRegistry {
     }
 
     /// Returns the `AuditAnchor` for `reading_hash`, or `None` if not anchored.
+    ///
+    /// # Arguments
+    /// * `reading_hash` — 32-byte SHA-256 hash to look up.
     pub fn verify(env: Env, reading_hash: BytesN<32>) -> Option<AuditAnchor> {
         env.storage().persistent().get(&DataKey::Anchor(reading_hash))
     }
 
-    /// Returns `true` if `reading_hash` has been anchored.
+    /// Returns `true` if `reading_hash` has been anchored, `false` otherwise.
     pub fn is_anchored(env: Env, reading_hash: BytesN<32>) -> bool {
         env.storage().persistent().has(&DataKey::Anchor(reading_hash))
     }
 
-    /// Returns the total number of anchored readings.
+    /// Returns the total number of reading hashes anchored so far.
     pub fn total_anchors(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::TotalAnchors).unwrap_or(0)
     }
 
     /// Returns the admin address.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
     pub fn admin(env: Env) -> soroban_sdk::Address {
         env.storage().instance().get(&DataKey::Admin).expect("not initialized")
     }

--- a/apps/contracts/community_governance/src/lib.rs
+++ b/apps/contracts/community_governance/src/lib.rs
@@ -142,16 +142,15 @@ fn bitmap_set(env: &Env, proposal_id: u32, idx: u32) {
 
 #[contractimpl]
 impl CommunityGovernance {
-    /// Initialise the contract.
+    /// Initialise the contract. Must be called exactly once after deployment.
     ///
     /// # Arguments
     /// * `admin`                 — administrator address.
-    /// * `quorum`                — minimum yes-vote percentage to pass (1–100).
+    /// * `quorum`                — minimum yes-vote percentage required to pass (1–100).
     /// * `voting_period_ledgers` — number of ledgers each proposal stays open.
     ///
     /// # Panics
     /// * `"already initialized"` if called more than once.
-    /// * `"quorum must be 1-100"` if `quorum` is out of range.
     pub fn initialize(env: Env, admin: Address, quorum: u32, voting_period_ledgers: u32) {
         if env.storage().instance().has(&DataKey::Admin) { panic!("already initialized"); }
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -165,6 +164,7 @@ impl CommunityGovernance {
         env.storage().instance().set(&DataKey::Version, &String::from_str(&env, VERSION));
     }
 
+    /// Returns the contract version string (e.g. `"1.0.0"`).
     pub fn get_version(env: Env) -> String {
         env.storage().instance()
             .get(&DataKey::Version)
@@ -172,6 +172,15 @@ impl CommunityGovernance {
     }
 
     /// Migrate state schema to a new version. Admin-only.
+    ///
+    /// # Arguments
+    /// * `new_version` — version string to store (e.g. `"2.0.0"`).
+    ///
+    /// # Authorization
+    /// Requires `admin` authorisation.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
     pub fn migrate(env: Env, new_version: String) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
         admin.require_auth();

--- a/apps/contracts/energy_token/src/lib.rs
+++ b/apps/contracts/energy_token/src/lib.rs
@@ -40,7 +40,14 @@ pub struct EnergyToken;
 
 #[contractimpl]
 impl EnergyToken {
-    /// Initialise the contract.
+    /// Initialise the contract. Must be called exactly once after deployment.
+    ///
+    /// # Arguments
+    /// * `admin`  — address that can rotate the `minter` via [`set_minter`].
+    /// * `minter` — the only address authorised to call [`mint`].
+    ///
+    /// # Panics
+    /// Panics with `"already initialized"` if called more than once.
     pub fn initialize(env: Env, admin: Address, minter: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
@@ -54,20 +61,24 @@ impl EnergyToken {
 
     // ── SEP-41 metadata ─────────────────────────────────────────────────────
 
+    /// Returns the human-readable token name: `"SolarProof kWh"`.
     pub fn name(env: Env) -> String {
         String::from_str(&env, "SolarProof kWh")
     }
 
+    /// Returns the token ticker symbol: `"SKWH"`.
     pub fn symbol(env: Env) -> String {
         String::from_str(&env, "SKWH")
     }
 
+    /// Returns the number of decimal places: `7` (matching Stellar's stroop precision).
     pub fn decimals(_env: Env) -> u32 {
         7
     }
 
     // ── SEP-41 balance / transfer ────────────────────────────────────────────
 
+    /// Returns the token balance of `account`. Returns `0` for unknown accounts.
     pub fn balance(env: Env, account: Address) -> i128 {
         env.storage()
             .persistent()
@@ -75,6 +86,24 @@ impl EnergyToken {
             .unwrap_or(0)
     }
 
+    /// Transfer `amount` tokens from `from` to `to`.
+    ///
+    /// # Arguments
+    /// * `from`   — sender (must authorise).
+    /// * `to`     — recipient.
+    /// * `amount` — number of tokens to transfer (must be positive).
+    ///
+    /// # Authorization
+    /// Requires `from` authorisation.
+    ///
+    /// # Panics
+    /// * `"amount must be positive"` if `amount <= 0`.
+    /// * `"contract is paused"` if the contract is paused.
+    /// * `"token is retired"` if `from` has been retired.
+    /// * `"insufficient balance"` if `from` has fewer tokens than `amount`.
+    ///
+    /// # Events
+    /// Emits `(topic: "transfer", data: (from, to, amount))`.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -87,6 +116,7 @@ impl EnergyToken {
     // ── SEP-41 allowance / approve ───────────────────────────────────────────
 
     /// Returns the amount `spender` is allowed to spend on behalf of `from`.
+    /// Returns `0` if no allowance has been set.
     pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
         env.storage()
             .persistent()
@@ -95,9 +125,21 @@ impl EnergyToken {
     }
 
     /// Approve `spender` to spend up to `amount` tokens from `from`.
+    /// Setting `amount` to `0` revokes the allowance.
+    ///
+    /// # Arguments
+    /// * `from`    — token owner (must authorise).
+    /// * `spender` — address being granted the allowance.
+    /// * `amount`  — maximum tokens `spender` may spend (must be ≥ 0).
     ///
     /// # Authorization
     /// Requires `from` authorisation.
+    ///
+    /// # Panics
+    /// * `"amount must be non-negative"` if `amount < 0`.
+    ///
+    /// # Events
+    /// Emits `(topic: "approve", data: (from, spender, amount))`.
     pub fn approve(env: Env, from: Address, spender: Address, amount: i128) {
         from.require_auth();
         assert!(amount >= 0, "amount must be non-negative");
@@ -110,8 +152,24 @@ impl EnergyToken {
 
     /// Transfer `amount` tokens from `from` to `to` using caller's allowance.
     ///
+    /// # Arguments
+    /// * `spender` — address spending the allowance (must authorise).
+    /// * `from`    — token owner whose allowance is consumed.
+    /// * `to`      — recipient.
+    /// * `amount`  — number of tokens to transfer (must be positive).
+    ///
     /// # Authorization
     /// Requires `spender` (caller) authorisation.
+    ///
+    /// # Panics
+    /// * `"amount must be positive"` if `amount <= 0`.
+    /// * `"contract is paused"` if the contract is paused.
+    /// * `"token is retired"` if `from` has been retired.
+    /// * `"insufficient allowance"` if `spender`'s allowance is less than `amount`.
+    /// * `"insufficient balance"` if `from` has fewer tokens than `amount`.
+    ///
+    /// # Events
+    /// Emits `(topic: "transfer", data: (from, to, amount))`.
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -124,8 +182,22 @@ impl EnergyToken {
 
     /// Burn `amount` tokens from `from` using caller's allowance.
     ///
+    /// # Arguments
+    /// * `spender` — address spending the allowance (must authorise).
+    /// * `from`    — token owner whose tokens are burned.
+    /// * `amount`  — number of tokens to burn (must be positive).
+    ///
     /// # Authorization
     /// Requires `spender` (caller) authorisation.
+    ///
+    /// # Panics
+    /// * `"amount must be positive"` if `amount <= 0`.
+    /// * `"contract is paused"` if the contract is paused.
+    /// * `"insufficient allowance"` if `spender`'s allowance is less than `amount`.
+    /// * `"insufficient balance"` if `from` has fewer tokens than `amount`.
+    ///
+    /// # Events
+    /// Emits `(topic: "burn", data: (from, amount))`.
     pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -139,6 +211,24 @@ impl EnergyToken {
 
     // ── Mint / burn (privileged) ─────────────────────────────────────────────
 
+    /// Mint `amount` new tokens to `to`. Only the registered `minter` may call this.
+    ///
+    /// # Arguments
+    /// * `to`     — recipient address.
+    /// * `amount` — number of tokens to mint (must be positive).
+    ///
+    /// # Authorization
+    /// Requires `minter` authorisation.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
+    /// * `"amount must be positive"` if `amount <= 0`.
+    /// * `"contract is paused"` if the contract is paused.
+    /// * `"overflow: balance"` if minting would overflow `to`'s balance.
+    /// * `"overflow: total_minted"` if minting would overflow the total supply counter.
+    ///
+    /// # Events
+    /// Emits `(topic: "mint", data: (to, amount))`.
     pub fn mint(env: Env, to: Address, amount: i128) {
         let minter: Address = env
             .storage()
@@ -167,6 +257,22 @@ impl EnergyToken {
         env.events().publish((symbol_short!("mint"),), (to, amount));
     }
 
+    /// Burn `amount` tokens from `from`. The token holder calls this directly.
+    ///
+    /// # Arguments
+    /// * `from`   — address whose tokens are burned (must authorise).
+    /// * `amount` — number of tokens to burn (must be positive).
+    ///
+    /// # Authorization
+    /// Requires `from` authorisation.
+    ///
+    /// # Panics
+    /// * `"amount must be positive"` if `amount <= 0`.
+    /// * `"contract is paused"` if the contract is paused.
+    /// * `"insufficient balance"` if `from` has fewer tokens than `amount`.
+    ///
+    /// # Events
+    /// Emits `(topic: "burn", data: (from, amount))`.
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -176,6 +282,7 @@ impl EnergyToken {
         env.events().publish((symbol_short!("burn"),), (from, amount));
     }
 
+    /// Returns the current circulating supply: `total_minted - total_burned`.
     pub fn total_supply(env: Env) -> i128 {
         let minted: i128 = env
             .storage()
@@ -190,6 +297,16 @@ impl EnergyToken {
         minted - burned
     }
 
+    /// Replace the authorised minter address. Admin-only.
+    ///
+    /// # Arguments
+    /// * `new_minter` — address that will be authorised to call [`mint`].
+    ///
+    /// # Authorization
+    /// Requires `admin` authorisation.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
     pub fn set_minter(env: Env, new_minter: Address) {
         let admin: Address = env
             .storage()
@@ -200,6 +317,10 @@ impl EnergyToken {
         env.storage().instance().set(&DataKey::Minter, &new_minter);
     }
 
+    /// Returns the admin address.
+    ///
+    /// # Panics
+    /// * `"not initialized"` if the contract has not been initialised.
     pub fn admin(env: Env) -> Address {
         env.storage()
             .instance()


### PR DESCRIPTION
Adds `///` doc comments to every public function across all three Soroban contracts so auditors and integrators have complete inline documentation and `cargo doc` generates full output.

Closes #68