### PR TITLE
feat(migrations): versioned SQL migrations with rollback scripts (#37)

### DIFF
--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -24,8 +24,21 @@ jobs:
       - name: Start Supabase local stack
         run: supabase start
 
-      - name: Reset DB (applies all migrations + seed)
+      - name: Apply all migrations (forward)
         run: supabase db reset
+
+      - name: Verify rollback scripts exist for every migration
+        run: |
+          missing=0
+          for f in supabase/migrations/*.sql; do
+            base=$(basename "$f" .sql)
+            down="supabase/migrations/rollbacks/${base}.down.sql"
+            if [ ! -f "$down" ]; then
+              echo "Missing rollback: $down"
+              missing=1
+            fi
+          done
+          exit $missing
 
       - name: Stop Supabase local stack
         if: always()

--- a/supabase/migrations/20260426000007_operator_sessions.sql
+++ b/supabase/migrations/20260426000007_operator_sessions.sql
@@ -1,0 +1,16 @@
+-- Migration 007: operator_sessions for JWT refresh token rotation
+-- Tracks active refresh tokens so they can be invalidated on logout.
+
+create table operator_sessions (
+  id            uuid        primary key default gen_random_uuid(),
+  operator_id   uuid        not null,   -- references auth.users(id) via Supabase Auth
+  refresh_token text        not null unique,
+  expires_at    timestamptz not null,
+  revoked       boolean     not null default false,
+  created_at    timestamptz not null default now()
+);
+
+create index operator_sessions_operator_id_idx on operator_sessions (operator_id);
+create index operator_sessions_refresh_token_idx on operator_sessions (refresh_token);
+-- Purge expired/revoked sessions via pg_cron or a scheduled job
+create index operator_sessions_expires_at_idx on operator_sessions (expires_at) where not revoked;

--- a/supabase/migrations/rollbacks/20240101000001_initial_schema.down.sql
+++ b/supabase/migrations/rollbacks/20240101000001_initial_schema.down.sql
@@ -1,0 +1,5 @@
+-- Rollback 001: drop initial schema tables (reverse dependency order)
+drop table if exists certificates cascade;
+drop table if exists readings cascade;
+drop table if exists meters cascade;
+drop table if exists cooperatives cascade;

--- a/supabase/migrations/rollbacks/20240101000002_indexes.down.sql
+++ b/supabase/migrations/rollbacks/20240101000002_indexes.down.sql
@@ -1,0 +1,7 @@
+-- Rollback 002: drop indexes added in migration 002
+drop index if exists meters_cooperative_id_idx;
+drop index if exists readings_meter_id_idx;
+drop index if exists readings_reading_hash_idx;
+drop index if exists certificates_cooperative_id_idx;
+drop index if exists certificates_reading_hash_idx;
+drop index if exists certificates_mint_tx_hash_idx;

--- a/supabase/migrations/rollbacks/20240101000003_rls.down.sql
+++ b/supabase/migrations/rollbacks/20240101000003_rls.down.sql
@@ -1,0 +1,13 @@
+-- Rollback 003: drop RLS policies and helper functions
+drop policy if exists "operators: own cooperative" on cooperatives;
+drop policy if exists "operators: own meters" on meters;
+drop policy if exists "operators: own readings" on readings;
+drop policy if exists "operators: own certificates" on certificates;
+
+alter table cooperatives disable row level security;
+alter table meters disable row level security;
+alter table readings disable row level security;
+alter table certificates disable row level security;
+
+drop function if exists auth.cooperative_id();
+drop function if exists auth.is_admin();

--- a/supabase/migrations/rollbacks/20240101000004_rls_tests.down.sql
+++ b/supabase/migrations/rollbacks/20240101000004_rls_tests.down.sql
@@ -1,0 +1,3 @@
+-- Rollback 004: drop RLS test helpers (pgTAP tests are run-and-discard; nothing to undo)
+-- The pgTAP extension itself is left in place as other tests may use it.
+select 1; -- no-op

--- a/supabase/migrations/rollbacks/20240101000005_audit_log.down.sql
+++ b/supabase/migrations/rollbacks/20240101000005_audit_log.down.sql
@@ -1,0 +1,2 @@
+-- Rollback 005a: drop audit_log table and its indexes/rules
+drop table if exists audit_log cascade;

--- a/supabase/migrations/rollbacks/20240101000005_idempotency_keys.down.sql
+++ b/supabase/migrations/rollbacks/20240101000005_idempotency_keys.down.sql
@@ -1,0 +1,2 @@
+-- Rollback 005c: drop idempotency_keys table
+drop table if exists idempotency_keys cascade;

--- a/supabase/migrations/rollbacks/20240101000005_jobs.down.sql
+++ b/supabase/migrations/rollbacks/20240101000005_jobs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback 005b: drop jobs table, trigger, and helper function
+drop table if exists jobs cascade;
+drop function if exists set_updated_at() cascade;

--- a/supabase/migrations/rollbacks/20240101000006_webhooks.down.sql
+++ b/supabase/migrations/rollbacks/20240101000006_webhooks.down.sql
@@ -1,0 +1,3 @@
+-- Rollback 006: drop webhook tables
+drop table if exists webhook_logs cascade;
+drop table if exists webhook_endpoints cascade;

--- a/supabase/migrations/rollbacks/20260426000007_operator_sessions.down.sql
+++ b/supabase/migrations/rollbacks/20260426000007_operator_sessions.down.sql
@@ -1,0 +1,2 @@
+-- Rollback 007: drop operator_sessions table
+drop table if exists operator_sessions cascade;


### PR DESCRIPTION
## Summary

Closes #37

Implements a reproducible migration system with rollback scripts for every migration file.

## Changes

- **Rollback scripts** added in `supabase/migrations/rollbacks/` for all existing migrations (001–006), each named `<timestamp>_<name>.down.sql`
- **Migration 007** (`20260426000007_operator_sessions.sql`): new `operator_sessions` table for JWT refresh token rotation (required by #40)
- **CI** (`.github/workflows/supabase.yml`): updated to verify a rollback script exists for every migration file before merge

## Testing

CI runs `supabase db reset` (applies all migrations forward) then checks that every `.sql` migration has a corresponding `.down.sql` rollback.

## Checklist
- [x] Migrations stored in `/supabase/migrations` as versioned SQL files
- [x] `supabase db reset` applies pending migrations
- [x] Rollback scripts provided for each migration
- [x] CI runs migrations against test DB before merge