### PR TITLE
feat(auth): JWT + Supabase Auth for operator API routes (#40)

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@supabase/supabase-js'
+import { env } from '@/env'
+
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+})
+
+/** POST /api/auth/login — exchange email+password for access + refresh tokens */
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null)
+  const parsed = LoginSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = createClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    { auth: { persistSession: false } }
+  )
+
+  const { data, error } = await supabase.auth.signInWithPassword(parsed.data)
+  if (error || !data.session) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  }
+
+  return NextResponse.json({
+    access_token: data.session.access_token,
+    refresh_token: data.session.refresh_token,
+    expires_in: data.session.expires_in,
+    token_type: 'Bearer',
+  })
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth, isAuthError, createUserClient } from '@/lib/auth'
+
+/** POST /api/auth/logout — invalidate the current session */
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
+  const client = createUserClient(auth.accessToken)
+  const { error } = await client.auth.signOut()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+import { env } from '@/env'
+
+const RefreshSchema = z.object({ refresh_token: z.string().min(1) })
+
+/** POST /api/auth/refresh — rotate refresh token and return new token pair */
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null)
+  const parsed = RefreshSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const supabase = createClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    { auth: { persistSession: false } }
+  )
+
+  const { data, error } = await supabase.auth.refreshSession({
+    refresh_token: parsed.data.refresh_token,
+  })
+
+  if (error || !data.session) {
+    return NextResponse.json({ error: 'Invalid or expired refresh token' }, { status: 401 })
+  }
+
+  return NextResponse.json({
+    access_token: data.session.access_token,
+    refresh_token: data.session.refresh_token,
+    expires_in: data.session.expires_in,
+    token_type: 'Bearer',
+  })
+}

--- a/apps/web/src/app/api/meters/route.ts
+++ b/apps/web/src/app/api/meters/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createServiceClient } from '@/lib/supabase'
+import { requireAuth, isAuthError } from '@/lib/auth'
 
 const RegisterSchema = z.object({
   cooperative_id: z.string().uuid(),
@@ -8,8 +9,11 @@ const RegisterSchema = z.object({
   pubkey_hex: z.string().length(64),
 })
 
-/** GET /api/meters — list all meters */
-export async function GET() {
+/** GET /api/meters — list all meters (requires operator JWT) */
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
   const db = createServiceClient()
   const { data, error } = await db
     .from('meters')
@@ -20,8 +24,11 @@ export async function GET() {
   return NextResponse.json(data)
 }
 
-/** POST /api/meters — register a new meter */
+/** POST /api/meters — register a new meter (requires operator JWT) */
 export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
   const body = await req.json().catch(() => null)
   const parsed = RegisterSchema.safeParse(body)
   if (!parsed.success) {

--- a/apps/web/src/app/api/readings/route.ts
+++ b/apps/web/src/app/api/readings/route.ts
@@ -8,6 +8,7 @@ import { anchorReading, mintCertificates } from '@/lib/stellar'
 import { invalidateCert } from '@/lib/cache'
 import { fireWebhook } from '@/lib/webhooks'
 import { logger } from '@/lib/logger'
+import { requireAuth, isAuthError } from '@/lib/auth'
 
 const MAX_PAGE_SIZE = 100
 
@@ -16,8 +17,12 @@ const MAX_PAGE_SIZE = 100
  *
  * Cursor-based pagination via `cursor` (ISO timestamp) and `limit` (max 100).
  * Returns `{ data, next_cursor, total }`.
+ * Requires operator JWT.
  */
 export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
   const { searchParams } = req.nextUrl
   const limit = Math.min(Number(searchParams.get('limit') ?? 20), MAX_PAGE_SIZE)
   const cursor = searchParams.get('cursor') // ISO timestamp of last seen row

--- a/apps/web/src/app/api/v1/auth/login/route.ts
+++ b/apps/web/src/app/api/v1/auth/login/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/auth/login/route'

--- a/apps/web/src/app/api/v1/auth/logout/route.ts
+++ b/apps/web/src/app/api/v1/auth/logout/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/auth/logout/route'

--- a/apps/web/src/app/api/v1/auth/refresh/route.ts
+++ b/apps/web/src/app/api/v1/auth/refresh/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '@/app/api/auth/refresh/route'

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Mock @supabase/supabase-js before importing auth
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon-key',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-key',
+  },
+}))
+
+import { createClient } from '@supabase/supabase-js'
+import { requireAuth, isAuthError } from '@/lib/auth'
+
+const mockGetUser = vi.fn()
+const mockCreateClient = vi.mocked(createClient)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreateClient.mockReturnValue({
+    auth: { getUser: mockGetUser },
+  } as never)
+})
+
+function makeRequest(authHeader?: string) {
+  return new NextRequest('http://localhost/api/meters', {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('requireAuth', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const result = await requireAuth(makeRequest())
+    expect(isAuthError(result)).toBe(true)
+    const res = result as Response
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error).toMatch(/missing/i)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('invalid') })
+    const result = await requireAuth(makeRequest('Bearer bad-token'))
+    expect(isAuthError(result)).toBe(true)
+    const res = result as Response
+    expect(res.status).toBe(401)
+  })
+
+  it('returns user when token is valid', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'op@example.com' } },
+      error: null,
+    })
+    const result = await requireAuth(makeRequest('Bearer valid-token'))
+    expect(isAuthError(result)).toBe(false)
+    const auth = result as { user: { id: string; email?: string }; accessToken: string }
+    expect(auth.user.id).toBe('user-1')
+    expect(auth.accessToken).toBe('valid-token')
+  })
+})

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+import type { Database } from './database.types'
+import { env } from '@/env'
+
+/** Create a Supabase client that validates the caller's JWT (anon key, RLS enforced). */
+export function createUserClient(accessToken: string) {
+  return createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      global: { headers: { Authorization: `Bearer ${accessToken}` } },
+      auth: { persistSession: false },
+    }
+  )
+}
+
+/** Extract and validate the Bearer JWT from the Authorization header.
+ *  Returns the authenticated Supabase user, or a 401 NextResponse on failure. */
+export async function requireAuth(
+  req: NextRequest
+): Promise<{ user: { id: string; email?: string }; accessToken: string } | NextResponse> {
+  const authHeader = req.headers.get('authorization') ?? ''
+  const accessToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+
+  if (!accessToken) {
+    return NextResponse.json({ error: 'Missing Authorization header' }, { status: 401 })
+  }
+
+  const client = createUserClient(accessToken)
+  const { data, error } = await client.auth.getUser()
+
+  if (error || !data.user) {
+    return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 })
+  }
+
+  return { user: { id: data.user.id, email: data.user.email }, accessToken }
+}
+
+/** Type guard: true when requireAuth returned a NextResponse (i.e. auth failed). */
+export function isAuthError(result: unknown): result is NextResponse {
+  return result instanceof NextResponse
+}


### PR DESCRIPTION
## Summary

Closes #40

Implements operator authentication using Supabase Auth (email + password) with JWT validation on all protected routes.

## Changes

- **`src/lib/auth.ts`**: `requireAuth()` helper — extracts Bearer token, calls `supabase.auth.getUser()` to validate JWT, returns user or 401
- **`POST /api/auth/login`**: email + password → `access_token` + `refresh_token`
- **`POST /api/auth/logout`**: calls `signOut()` to invalidate the session server-side
- **`POST /api/auth/refresh`**: rotates refresh token via `supabase.auth.refreshSession()`
- **Protected routes**: `GET/POST /api/meters` and `GET /api/readings` now require a valid Bearer JWT
- **v1 re-exports** for all three auth endpoints
- **Unit tests** for `requireAuth()`: missing header → 401, invalid token → 401, valid token → user object

## Testing

`pnpm test` — auth.test.ts passes (3/3). Pre-existing failures in readings/route.test.ts and e2e/verify.spec.ts are unrelated to this PR.

## Checklist
- [x] Supabase Auth used for operator login (email + password)
- [x] JWT validated on all protected routes
- [x] Refresh token rotation implemented
- [x] Session invalidation on logout