### PR TITLE
feat(health): comprehensive health check endpoint GET /api/health (#45)

### DIFF
--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -1,12 +1,79 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  createServiceClient: vi.fn(),
+}))
+
+vi.mock('@/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+    SUPABASE_SERVICE_ROLE_KEY: 'service',
+    NEXT_PUBLIC_STELLAR_RPC_URL: 'https://soroban-testnet.stellar.org',
+  },
+}))
+
+import { createServiceClient } from '@/lib/supabase'
 import { GET } from '@/app/api/health/route'
 
+const mockSelect = vi.fn()
+const mockFrom = vi.fn(() => ({ select: mockSelect }))
+const mockCreateServiceClient = vi.mocked(createServiceClient)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreateServiceClient.mockReturnValue({ from: mockFrom } as never)
+  // Default: DB responds fast
+  mockSelect.mockResolvedValue({ data: null, error: null, count: 0 })
+  // Default: Stellar RPC responds fast with ok
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ result: 'healthy' }) }))
+})
+
 describe('GET /api/health', () => {
-  it('returns 200 with status ok', async () => {
+  it('returns 200 with status ok when all checks pass', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('ok')
+    expect(body.checks.database.status).toBe('ok')
+    expect(body.checks.stellar_rpc.status).toBe('ok')
+    expect(typeof body.ts).toBe('number')
+  })
+
+  it('returns 503 when DB check errors', async () => {
+    mockSelect.mockRejectedValue(new Error('connection refused'))
+    const res = await GET()
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.status).toBe('error')
+    expect(body.checks.database.status).toBe('error')
+  })
+
+  it('returns 503 when Stellar RPC errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+    const res = await GET()
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.status).toBe('error')
+    expect(body.checks.stellar_rpc.status).toBe('error')
+  })
+
+  it('returns 200 with degraded status when a check is slow', async () => {
+    // Simulate slow DB (> 300 ms threshold) by making the mock delay
+    mockSelect.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({ data: null, error: null, count: 0 }), 310))
+    )
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('degraded')
+    expect(body.checks.database.status).toBe('degraded')
+  })
+
+  it('includes latency_ms for each check', async () => {
     const res = await GET()
     const body = await res.json()
-    expect(res.status).toBe(200)
-    expect(body.status).toBe('ok')
-    expect(typeof body.ts).toBe('number')
+    expect(typeof body.checks.database.latency_ms).toBe('number')
+    expect(typeof body.checks.stellar_rpc.latency_ms).toBe('number')
   })
 })

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,5 +1,82 @@
 import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { env } from '@/env'
 
+const DEGRADED_THRESHOLD_MS = 300 // mark degraded if a check exceeds this
+const TIMEOUT_MS = 450            // hard timeout per check (keeps total < 500 ms)
+
+type CheckStatus = 'ok' | 'degraded' | 'error'
+
+interface CheckResult {
+  status: CheckStatus
+  latency_ms: number
+  error?: string
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('timeout')), ms)
+  })
+  try {
+    const result = await Promise.race([promise, timeout])
+    clearTimeout(timer!)
+    return result
+  } catch (err) {
+    clearTimeout(timer!)
+    throw err
+  }
+}
+
+async function checkDatabase(): Promise<CheckResult> {
+  const start = Date.now()
+  try {
+    const db = createServiceClient()
+    await withTimeout(
+      db.from('cooperatives').select('id', { count: 'exact', head: true }),
+      TIMEOUT_MS
+    )
+    const latency_ms = Date.now() - start
+    return { status: latency_ms > DEGRADED_THRESHOLD_MS ? 'degraded' : 'ok', latency_ms }
+  } catch (err) {
+    return { status: 'error', latency_ms: Date.now() - start, error: String(err) }
+  }
+}
+
+async function checkStellarRpc(): Promise<CheckResult> {
+  const start = Date.now()
+  try {
+    const res = await withTimeout(
+      fetch(env.NEXT_PUBLIC_STELLAR_RPC_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth' }),
+      }),
+      TIMEOUT_MS
+    )
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const latency_ms = Date.now() - start
+    return { status: latency_ms > DEGRADED_THRESHOLD_MS ? 'degraded' : 'ok', latency_ms }
+  } catch (err) {
+    return { status: 'error', latency_ms: Date.now() - start, error: String(err) }
+  }
+}
+
+/** GET /api/health — service health with DB + Stellar RPC checks */
 export async function GET() {
-  return NextResponse.json({ status: 'ok', ts: Date.now() })
+  const [db, stellar] = await Promise.all([checkDatabase(), checkStellarRpc()])
+
+  const overallStatus: CheckStatus =
+    db.status === 'error' || stellar.status === 'error'
+      ? 'error'
+      : db.status === 'degraded' || stellar.status === 'degraded'
+      ? 'degraded'
+      : 'ok'
+
+  const httpStatus = overallStatus === 'error' ? 503 : 200
+
+  return NextResponse.json(
+    { status: overallStatus, ts: Date.now(), checks: { database: db, stellar_rpc: stellar } },
+    { status: httpStatus }
+  )
 }


### PR DESCRIPTION
## Summary

Closes #45

Replaces the minimal `{ status: 'ok', ts }` health route with a full dependency-checking endpoint.

## Changes

**`apps/web/src/app/api/health/route.ts`**
- Runs DB and Stellar RPC checks in parallel (`Promise.all`)
- DB check: lightweight `SELECT count` on `cooperatives` via service client
- Stellar RPC check: `POST getHealth` JSON-RPC call to the configured RPC URL
- Each check has a 450 ms hard timeout (keeps total response < 500 ms)
- Checks exceeding 300 ms are marked `degraded` (not `error`)
- Returns `200` for `ok`/`degraded`, `503` for `error`

**Response shape:**
```json
{
  "status": "ok" | "degraded" | "error",
  "ts": 1714000000000,
  "checks": {
    "database": { "status": "ok", "latency_ms": 12 },
    "stellar_rpc": { "status": "ok", "latency_ms": 45 }
  }
}
```

## Testing

5 unit tests pass:
- ✅ 200 ok when all checks pass
- ✅ 503 when DB errors
- ✅ 503 when Stellar RPC errors
- ✅ 200 degraded when a check is slow (> 300 ms)
- ✅ latency_ms present in each check

## Checklist
- [x] GET /api/health returns 200 with service status
- [x] Checks: DB connectivity, Stellar RPC reachability
- [x] Returns degraded status if dependencies are slow
- [x] Response time < 500 ms (450 ms per-check timeout)