### PR TITLE
feat(api): implement CORS policy for API routes

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -57,3 +57,9 @@ UPSTASH_REDIS_REST_TOKEN=your-token
 # Create a source at https://logs.betterstack.com and paste the token here.
 # Retention: 30 days. Alerts configured in the Better Stack dashboard.
 LOGTAIL_SOURCE_TOKEN=
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# Comma-separated list of origins allowed to call the API from a browser.
+# In development, http://localhost:3000 is always permitted.
+# Example: https://solarproof.vercel.app,https://staging.solarproof.vercel.app
+CORS_ALLOWED_ORIGINS=https://solarproof.vercel.app

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -4,6 +4,9 @@ import { z } from 'zod'
 export const env = createEnv({
   server: {
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+    // Comma-separated list of allowed CORS origins.
+    // Example: https://solarproof.vercel.app,https://staging.solarproof.vercel.app
+    CORS_ALLOWED_ORIGINS: z.string().optional(),
     // Secrets Manager ARN for the active minter key (production)
     MINTER_SECRET_ARN: z.string().min(1).optional(),
     // ARN of the previous key — set during the 24-h rotation grace window
@@ -23,6 +26,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    CORS_ALLOWED_ORIGINS: process.env.CORS_ALLOWED_ORIGINS,
     MINTER_SECRET_ARN: process.env.MINTER_SECRET_ARN,
     MINTER_PREVIOUS_SECRET_ARN: process.env.MINTER_PREVIOUS_SECRET_ARN,
     MINTER_SECRET_KEY: process.env.MINTER_SECRET_KEY,

--- a/apps/web/src/lib/cors.test.ts
+++ b/apps/web/src/lib/cors.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('getCorsHeaders', () => {
+  const PROD_ORIGIN = 'https://solarproof.vercel.app'
+  const DEV_ORIGIN = 'http://localhost:3000'
+  const UNKNOWN_ORIGIN = 'https://evil.example.com'
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns null for a null origin', async () => {
+    const { getCorsHeaders } = await import('./cors')
+    expect(getCorsHeaders(null)).toBeNull()
+  })
+
+  it('returns null for an unknown origin', async () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', PROD_ORIGIN)
+    vi.stubEnv('NODE_ENV', 'production')
+    const { getCorsHeaders } = await import('./cors')
+    expect(getCorsHeaders(UNKNOWN_ORIGIN)).toBeNull()
+  })
+
+  it('allows a configured production origin', async () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', PROD_ORIGIN)
+    vi.stubEnv('NODE_ENV', 'production')
+    const { getCorsHeaders } = await import('./cors')
+    const headers = getCorsHeaders(PROD_ORIGIN)
+    expect(headers).not.toBeNull()
+    expect(headers!['Access-Control-Allow-Origin']).toBe(PROD_ORIGIN)
+    expect(headers!['Access-Control-Allow-Credentials']).toBe('true')
+    expect(headers!['Vary']).toBe('Origin')
+  })
+
+  it('allows localhost in development even without explicit config', async () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', '')
+    vi.stubEnv('NODE_ENV', 'development')
+    const { getCorsHeaders } = await import('./cors')
+    const headers = getCorsHeaders(DEV_ORIGIN)
+    expect(headers).not.toBeNull()
+    expect(headers!['Access-Control-Allow-Origin']).toBe(DEV_ORIGIN)
+  })
+
+  it('blocks localhost in production when not explicitly configured', async () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', PROD_ORIGIN)
+    vi.stubEnv('NODE_ENV', 'production')
+    const { getCorsHeaders } = await import('./cors')
+    expect(getCorsHeaders(DEV_ORIGIN)).toBeNull()
+  })
+
+  it('allows multiple configured origins', async () => {
+    const origins = `${PROD_ORIGIN},https://staging.solarproof.vercel.app`
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', origins)
+    vi.stubEnv('NODE_ENV', 'production')
+    const { getCorsHeaders } = await import('./cors')
+    expect(getCorsHeaders('https://staging.solarproof.vercel.app')).not.toBeNull()
+    expect(getCorsHeaders(PROD_ORIGIN)).not.toBeNull()
+  })
+
+  it('includes allowed methods and headers', async () => {
+    vi.stubEnv('CORS_ALLOWED_ORIGINS', PROD_ORIGIN)
+    vi.stubEnv('NODE_ENV', 'production')
+    const { getCorsHeaders } = await import('./cors')
+    const headers = getCorsHeaders(PROD_ORIGIN)!
+    expect(headers['Access-Control-Allow-Methods']).toContain('POST')
+    expect(headers['Access-Control-Allow-Headers']).toContain('Authorization')
+  })
+})

--- a/apps/web/src/lib/cors.ts
+++ b/apps/web/src/lib/cors.ts
@@ -1,0 +1,45 @@
+/**
+ * CORS policy for SolarProof API routes.
+ *
+ * Allowed origins are controlled by the CORS_ALLOWED_ORIGINS environment
+ * variable (comma-separated list). In development, http://localhost:3000 is
+ * always permitted. Credentials mode is enabled so the browser sends cookies.
+ */
+
+const DEV_ORIGINS = ['http://localhost:3000']
+
+/** Parse the CORS_ALLOWED_ORIGINS env var into a Set of allowed origins. */
+function getAllowedOrigins(): Set<string> {
+  const raw = process.env.CORS_ALLOWED_ORIGINS ?? ''
+  const configured = raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean)
+  const origins = [...configured]
+  if (process.env.NODE_ENV !== 'production') {
+    origins.push(...DEV_ORIGINS)
+  }
+  return new Set(origins)
+}
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Correlation-Id',
+  'Access-Control-Allow-Credentials': 'true',
+  'Access-Control-Max-Age': '86400',
+} as const
+
+/**
+ * Return CORS response headers for the given request origin.
+ * Returns null if the origin is not allowed.
+ */
+export function getCorsHeaders(origin: string | null): Record<string, string> | null {
+  if (!origin) return null
+  const allowed = getAllowedOrigins()
+  if (!allowed.has(origin)) return null
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Vary': 'Origin',
+    ...CORS_HEADERS,
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { randomUUID } from 'crypto'
+import { getCorsHeaders } from '@/lib/cors'
 
 /**
  * Middleware that:
- * 1. Injects a correlation ID into every API request.
- * 2. Redirects unversioned /api/* routes to /api/v1/* with a deprecation header.
+ * 1. Enforces CORS policy — restricts origins to CORS_ALLOWED_ORIGINS + localhost in dev.
+ * 2. Handles OPTIONS preflight requests.
+ * 3. Injects a correlation ID into every API request.
+ * 4. Redirects unversioned /api/* routes to /api/v1/* with a deprecation header.
  *
  * Correlation ID:
  *   - Reads `X-Correlation-Id` from the incoming request if present.
@@ -17,6 +20,17 @@ import { randomUUID } from 'crypto'
  */
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl
+  const origin = req.headers.get('origin')
+  const corsHeaders = getCorsHeaders(origin)
+
+  // ── CORS preflight ────────────────────────────────────────────────────────
+  if (req.method === 'OPTIONS') {
+    if (corsHeaders) {
+      return new NextResponse(null, { status: 204, headers: corsHeaders })
+    }
+    // Origin not allowed — return 403
+    return new NextResponse(null, { status: 403 })
+  }
 
   // ── API versioning redirect ───────────────────────────────────────────────
   // Match /api/<segment> but NOT /api/v1/... or /api/docs (OpenAPI spec)
@@ -30,6 +44,11 @@ export function middleware(req: NextRequest) {
     // Propagate correlation ID on the redirect response too
     const correlationId = req.headers.get('x-correlation-id') ?? randomUUID()
     redirect.headers.set('x-correlation-id', correlationId)
+    if (corsHeaders) {
+      for (const [k, v] of Object.entries(corsHeaders)) {
+        redirect.headers.set(k, v)
+      }
+    }
     return redirect
   }
 
@@ -44,6 +63,14 @@ export function middleware(req: NextRequest) {
     },
   })
   res.headers.set('x-correlation-id', correlationId)
+
+  // ── Attach CORS headers ───────────────────────────────────────────────────
+  if (corsHeaders) {
+    for (const [k, v] of Object.entries(corsHeaders)) {
+      res.headers.set(k, v)
+    }
+  }
+
   return res
 }
 


### PR DESCRIPTION
## Summary

Implements CORS policy for all API routes, resolving the security gap where any origin could call the API from a browser.

## Changes

- **`src/lib/cors.ts`** — `getCorsHeaders(origin)` helper that reads `CORS_ALLOWED_ORIGINS` (comma-separated env var) and always permits `localhost:3000` in non-production environments
- **`src/middleware.ts`** — handles OPTIONS preflight (204 allowed / 403 blocked), attaches CORS headers to all API responses including versioning redirects
- **`src/env.ts`** — adds `CORS_ALLOWED_ORIGINS` to the validated server env schema
- **`.env.example`** — documents the new variable with an example value
- **`src/lib/cors.test.ts`** — 7 unit tests covering allowed/blocked origins, dev vs prod, multi-origin config, credentials, and header content

## Acceptance Criteria

- [x] CORS restricted to known origins (app domain + localhost in dev)
- [x] Preflight OPTIONS requests handled correctly
- [x] Credentials mode configured appropriately
- [x] CORS config managed via environment variable (`CORS_ALLOWED_ORIGINS`)

## Testing

All 7 CORS unit tests pass (`src/lib/cors.test.ts`).

Closes #46