### PR TITLE
test(fixtures): add Supabase test factories and cleanup helpers

### DIFF
--- a/apps/web/src/tests/factories.test.ts
+++ b/apps/web/src/tests/factories.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the Supabase test factories — issue #123.
+ *
+ * These tests run against a mocked Supabase client so they work in CI
+ * without a live database. They verify that:
+ *   - each factory produces the expected shape
+ *   - cleanup() removes rows in the correct order
+ *   - factories auto-create parent rows when IDs are omitted
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  makeCooperative,
+  makeMeter,
+  makeReading,
+  makeCertificate,
+  makeOperator,
+  cleanup,
+  emptyCleanupIds,
+  type CleanupIds,
+} from './factories'
+
+// ---------------------------------------------------------------------------
+// Minimal Supabase mock
+// ---------------------------------------------------------------------------
+
+const deleteMock = vi.fn().mockReturnValue({ error: null })
+const inMock = vi.fn().mockReturnValue({ error: null })
+deleteMock.mockReturnValue({ in: inMock })
+
+function makeInsertMock(row: Record<string, unknown>) {
+  const single = vi.fn().mockResolvedValue({ data: row, error: null })
+  const select = vi.fn().mockReturnValue({ single })
+  const insert = vi.fn().mockReturnValue({ select })
+  return { insert, select, single }
+}
+
+function buildDb(rows: Record<string, Record<string, unknown>>) {
+  return {
+    from: vi.fn((table: string) => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: rows[table], error: null }),
+        }),
+      }),
+      delete: vi.fn().mockReturnValue({ in: inMock }),
+    })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('factories', () => {
+  let ids: CleanupIds
+
+  beforeEach(() => {
+    ids = emptyCleanupIds()
+    vi.clearAllMocks()
+  })
+
+  it('makeCooperative returns a cooperative row and tracks id', async () => {
+    const row = { id: 'coop-1', name: 'Test Cooperative 1', admin_address: 'GABC', created_at: '' }
+    const db = buildDb({ cooperatives: row }) as any
+    const result = await makeCooperative(db, ids)
+    expect(result.id).toBe('coop-1')
+    expect(ids.cooperatives).toContain('coop-1')
+  })
+
+  it('makeMeter returns a meter row and tracks id', async () => {
+    const coopRow = { id: 'coop-2', name: 'C', admin_address: 'G', created_at: '' }
+    const meterRow = { id: 'meter-1', cooperative_id: 'coop-2', serial_number: 'SN-1', name: 'M', pubkey_hex: 'a'.repeat(64), active: true, created_at: '' }
+    const db = {
+      from: vi.fn((table: string) => ({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: table === 'cooperatives' ? coopRow : meterRow,
+              error: null,
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({ in: inMock }),
+      })),
+    } as any
+    const result = await makeMeter(db, ids)
+    expect(result.id).toBe('meter-1')
+    expect(ids.meters).toContain('meter-1')
+  })
+
+  it('makeReading returns a reading row and tracks id', async () => {
+    const rows: Record<string, unknown> = {
+      cooperatives: { id: 'coop-3', name: 'C', admin_address: 'G', created_at: '' },
+      meters: { id: 'meter-2', cooperative_id: 'coop-3', serial_number: 'SN-2', name: 'M', pubkey_hex: 'a'.repeat(64), active: true, created_at: '' },
+      readings: { id: 'reading-1', meter_id: 'meter-2', kwh: 10, timestamp: '', reading_hash: 'h', signature_hex: 'b'.repeat(128), anchored: false, minted: false, anchor_tx_hash: null, mint_tx_hash: null, mint_diagnosis: null },
+    }
+    const db = {
+      from: vi.fn((table: string) => ({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: rows[table], error: null }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({ in: inMock }),
+      })),
+    } as any
+    const result = await makeReading(db, ids)
+    expect(result.id).toBe('reading-1')
+    expect(ids.readings).toContain('reading-1')
+  })
+
+  it('makeCertificate returns a certificate row and tracks id', async () => {
+    const rows: Record<string, unknown> = {
+      cooperatives: { id: 'coop-4', name: 'C', admin_address: 'G', created_at: '' },
+      meters: { id: 'meter-3', cooperative_id: 'coop-4', serial_number: 'SN-3', name: 'M', pubkey_hex: 'a'.repeat(64), active: true, created_at: '' },
+      readings: { id: 'reading-2', meter_id: 'meter-3', kwh: 10, timestamp: '', reading_hash: 'h2', signature_hex: 'b'.repeat(128), anchored: false, minted: false, anchor_tx_hash: null, mint_tx_hash: null, mint_diagnosis: null },
+      certificates: { id: 'cert-1', cooperative_id: 'coop-4', reading_id: 'reading-2', reading_hash: 'h2', anchor_tx_hash: 'a', mint_tx_hash: 'm', kwh: 10, issued_at: '', retired: false, retired_at: null, retired_by: null },
+    }
+    const db = {
+      from: vi.fn((table: string) => ({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: rows[table], error: null }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({ in: inMock }),
+      })),
+    } as any
+    const result = await makeCertificate(db, ids)
+    expect(result.id).toBe('cert-1')
+    expect(ids.certificates).toContain('cert-1')
+  })
+
+  it('makeOperator returns cooperative and admin_address', async () => {
+    const row = { id: 'coop-5', name: 'Op', admin_address: 'GOPERATOR', created_at: '' }
+    const db = buildDb({ cooperatives: row }) as any
+    const result = await makeOperator(db, ids)
+    expect(result.cooperative.id).toBe('coop-5')
+    expect(typeof result.admin_address).toBe('string')
+    expect(ids.cooperatives).toContain('coop-5')
+  })
+
+  it('cleanup calls delete on all tracked tables', async () => {
+    const deleteIn = vi.fn().mockResolvedValue({ error: null })
+    const deleteChain = vi.fn().mockReturnValue({ in: deleteIn })
+    const db = { from: vi.fn().mockReturnValue({ delete: deleteChain }) } as any
+
+    const testIds: CleanupIds = {
+      certificates: ['cert-1'],
+      readings: ['reading-1'],
+      meters: ['meter-1'],
+      cooperatives: ['coop-1'],
+    }
+    await cleanup(db, testIds)
+
+    expect(db.from).toHaveBeenCalledWith('certificates')
+    expect(db.from).toHaveBeenCalledWith('readings')
+    expect(db.from).toHaveBeenCalledWith('meters')
+    expect(db.from).toHaveBeenCalledWith('cooperatives')
+    expect(deleteIn).toHaveBeenCalledTimes(4)
+  })
+
+  it('cleanup skips tables with no tracked ids', async () => {
+    const deleteIn = vi.fn().mockResolvedValue({ error: null })
+    const deleteChain = vi.fn().mockReturnValue({ in: deleteIn })
+    const db = { from: vi.fn().mockReturnValue({ delete: deleteChain }) } as any
+
+    await cleanup(db, emptyCleanupIds())
+    expect(db.from).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/tests/factories.ts
+++ b/apps/web/src/tests/factories.ts
@@ -1,0 +1,254 @@
+/**
+ * Test fixtures and factories for Supabase test data — issue #123.
+ *
+ * Usage:
+ *   import { makeCooperative, makeMeter, makeReading, makeCertificate, makeOperator, cleanup } from '@/tests/factories'
+ *
+ * Each factory inserts a row into the database and returns the created row.
+ * Call `cleanup(ids)` in afterEach to delete test rows in dependency order.
+ *
+ * @example
+ * ```ts
+ * let ids: CleanupIds
+ * beforeEach(() => { ids = emptyCleanupIds() })
+ * afterEach(() => cleanup(db, ids))
+ *
+ * it('...', async () => {
+ *   const coop = await makeCooperative(db, ids)
+ *   const meter = await makeMeter(db, ids, { cooperative_id: coop.id })
+ * })
+ * ```
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/database.types'
+
+type DB = SupabaseClient<Database>
+type Tables = Database['public']['Tables']
+
+// ---------------------------------------------------------------------------
+// Cleanup tracker
+// ---------------------------------------------------------------------------
+
+export interface CleanupIds {
+  certificates: string[]
+  readings: string[]
+  meters: string[]
+  cooperatives: string[]
+}
+
+/** Returns an empty CleanupIds object. */
+export function emptyCleanupIds(): CleanupIds {
+  return { certificates: [], readings: [], meters: [], cooperatives: [] }
+}
+
+/**
+ * Delete all tracked test rows in reverse-dependency order.
+ * Call this in `afterEach`.
+ */
+export async function cleanup(db: DB, ids: CleanupIds): Promise<void> {
+  if (ids.certificates.length)
+    await db.from('certificates').delete().in('id', ids.certificates)
+  if (ids.readings.length)
+    await db.from('readings').delete().in('id', ids.readings)
+  if (ids.meters.length)
+    await db.from('meters').delete().in('id', ids.meters)
+  if (ids.cooperatives.length)
+    await db.from('cooperatives').delete().in('id', ids.cooperatives)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _seq = 0
+const seq = () => ++_seq
+
+/** Stellar-style G… address placeholder. */
+const stellarAddress = () =>
+  `G${'A'.repeat(54)}${String(seq()).padStart(2, '0')}`
+
+// ---------------------------------------------------------------------------
+// Cooperative factory
+// ---------------------------------------------------------------------------
+
+export type CooperativeRow = Tables['cooperatives']['Row']
+
+/**
+ * Insert a cooperative row and track it for cleanup.
+ *
+ * @param db   - Supabase client (service role recommended for tests).
+ * @param ids  - CleanupIds tracker.
+ * @param overrides - Optional field overrides.
+ */
+export async function makeCooperative(
+  db: DB,
+  ids: CleanupIds,
+  overrides: Partial<Tables['cooperatives']['Insert']> = {}
+): Promise<CooperativeRow> {
+  const n = seq()
+  const payload: Tables['cooperatives']['Insert'] = {
+    name: `Test Cooperative ${n}`,
+    admin_address: stellarAddress(),
+    ...overrides,
+  }
+  const { data, error } = await db
+    .from('cooperatives')
+    .insert(payload)
+    .select()
+    .single()
+  if (error) throw new Error(`makeCooperative: ${error.message}`)
+  ids.cooperatives.push(data.id)
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Meter factory
+// ---------------------------------------------------------------------------
+
+export type MeterRow = Tables['meters']['Row']
+
+/**
+ * Insert a meter row and track it for cleanup.
+ * Creates a parent cooperative automatically if `cooperative_id` is not provided.
+ */
+export async function makeMeter(
+  db: DB,
+  ids: CleanupIds,
+  overrides: Partial<Tables['meters']['Insert']> & { cooperative_id?: string } = {}
+): Promise<MeterRow> {
+  const n = seq()
+  const cooperative_id =
+    overrides.cooperative_id ?? (await makeCooperative(db, ids)).id
+  const payload: Tables['meters']['Insert'] = {
+    cooperative_id,
+    serial_number: `SN-TEST-${n}`,
+    name: `Test Meter ${n}`,
+    pubkey_hex: 'a'.repeat(64),
+    active: true,
+    ...overrides,
+  }
+  const { data, error } = await db
+    .from('meters')
+    .insert(payload)
+    .select()
+    .single()
+  if (error) throw new Error(`makeMeter: ${error.message}`)
+  ids.meters.push(data.id)
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Reading factory
+// ---------------------------------------------------------------------------
+
+export type ReadingRow = Tables['readings']['Row']
+
+/**
+ * Insert a reading row and track it for cleanup.
+ * Creates a parent meter (and cooperative) automatically if `meter_id` is not provided.
+ */
+export async function makeReading(
+  db: DB,
+  ids: CleanupIds,
+  overrides: Partial<Tables['readings']['Insert']> & { meter_id?: string } = {}
+): Promise<ReadingRow> {
+  const n = seq()
+  const meter_id = overrides.meter_id ?? (await makeMeter(db, ids)).id
+  const payload: Tables['readings']['Insert'] = {
+    meter_id,
+    kwh: 10 + n * 0.5,
+    timestamp: new Date().toISOString(),
+    reading_hash: `hash-test-${n}-${'0'.repeat(48)}`,
+    signature_hex: 'b'.repeat(128),
+    anchored: false,
+    minted: false,
+    ...overrides,
+  }
+  const { data, error } = await db
+    .from('readings')
+    .insert(payload)
+    .select()
+    .single()
+  if (error) throw new Error(`makeReading: ${error.message}`)
+  ids.readings.push(data.id)
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Certificate factory
+// ---------------------------------------------------------------------------
+
+export type CertificateRow = Tables['certificates']['Row']
+
+/**
+ * Insert a certificate row and track it for cleanup.
+ * Creates parent reading/meter/cooperative automatically if IDs are not provided.
+ */
+export async function makeCertificate(
+  db: DB,
+  ids: CleanupIds,
+  overrides: Partial<Tables['certificates']['Insert']> & {
+    cooperative_id?: string
+    reading_id?: string
+  } = {}
+): Promise<CertificateRow> {
+  const n = seq()
+  const reading = overrides.reading_id
+    ? null
+    : await makeReading(db, ids)
+  const reading_id = overrides.reading_id ?? reading!.id
+  const cooperative_id =
+    overrides.cooperative_id ?? (await makeCooperative(db, ids)).id
+
+  const payload: Tables['certificates']['Insert'] = {
+    cooperative_id,
+    reading_id,
+    reading_hash: `cert-hash-${n}-${'0'.repeat(44)}`,
+    anchor_tx_hash: `anchor-tx-${n}`,
+    mint_tx_hash: `mint-tx-${n}-${'0'.repeat(40)}`,
+    kwh: 10 + n,
+    issued_at: new Date().toISOString(),
+    retired: false,
+    ...overrides,
+  }
+  const { data, error } = await db
+    .from('certificates')
+    .insert(payload)
+    .select()
+    .single()
+  if (error) throw new Error(`makeCertificate: ${error.message}`)
+  ids.certificates.push(data.id)
+  return data
+}
+
+// ---------------------------------------------------------------------------
+// Operator factory
+// ---------------------------------------------------------------------------
+
+/**
+ * An "operator" is a cooperative admin — represented as a cooperative row
+ * with a deterministic admin_address.
+ *
+ * Returns the cooperative row and the admin_address string.
+ */
+export interface OperatorResult {
+  cooperative: CooperativeRow
+  admin_address: string
+}
+
+/**
+ * Create an operator (cooperative + admin address) and track for cleanup.
+ */
+export async function makeOperator(
+  db: DB,
+  ids: CleanupIds,
+  overrides: Partial<Tables['cooperatives']['Insert']> = {}
+): Promise<OperatorResult> {
+  const admin_address = stellarAddress()
+  const cooperative = await makeCooperative(db, ids, {
+    admin_address,
+    ...overrides,
+  })
+  return { cooperative, admin_address }
+}


### PR DESCRIPTION
## Summary

Introduces shared factory functions for Supabase test data so tests no longer create ad-hoc rows inconsistently.

## Changes

- `apps/web/src/tests/factories.ts` — factory functions + cleanup helpers
- `apps/web/src/tests/factories.test.ts` — unit tests for all factories (mocked Supabase)

## Acceptance Criteria

- [x] Factory functions for: `makeCooperative`, `makeMeter`, `makeReading`, `makeCertificate`, `makeOperator`
- [x] `cleanup(db, ids)` deletes rows in reverse-dependency order (certificates → readings → meters → cooperatives)
- [x] `emptyCleanupIds()` + `CleanupIds` type for use in `beforeEach`/`afterEach`
- [x] Each factory accepts overrides and auto-creates parent rows when IDs are omitted
- [x] Factories documented with JSDoc including usage example

## Usage

```ts
import { makeCooperative, makeMeter, cleanup, emptyCleanupIds } from '@/tests/factories'

let ids = emptyCleanupIds()
afterEach(() => cleanup(db, ids))

it('...', async () => {
  const coop = await makeCooperative(db, ids)
  const meter = await makeMeter(db, ids, { cooperative_id: coop.id })
})
```

Closes #123