### PR TITLE
docs: complete OpenAPI 3.0 spec for all API endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,10 +5,32 @@ info:
   description: |
     End-to-end cryptographic proof of renewable energy — from physical meter to on-chain certificate.
 
-    All responses are JSON. Timestamps are ISO 8601 strings unless noted.
+    All responses are JSON unless noted. Timestamps are ISO 8601 strings unless noted.
+
+    ## Authentication
+
+    Protected endpoints require a Bearer JWT in the `Authorization` header:
+
+    ```
+    Authorization: Bearer <access_token>
+    ```
+
+    Obtain a token via `POST /api/auth/login`. Tokens expire; use `POST /api/auth/refresh` to rotate.
+
+    ## Versioning
+
+    All endpoints are available under `/api/v1/` (canonical) and `/api/` (legacy alias).
+    The `/api/v1/` prefix is preferred for new integrations.
+
+    ## Rate Limiting
+
+    Meter reading submissions are rate-limited to **60 requests per minute** per meter public key.
+    Exceeded requests receive `429 Too Many Requests` with a `Retry-After` header.
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
+  contact:
+    url: https://github.com/AnnabelJoe/solarproof
 
 servers:
   - url: https://solarproof.vercel.app
@@ -16,14 +38,147 @@ servers:
 
 security: []
 
+tags:
+  - name: auth
+    description: Authentication — obtain and rotate JWT tokens
+  - name: readings
+    description: Meter reading submission and retrieval
+  - name: certificates
+    description: Energy certificate management and retirement
+  - name: meters
+    description: Meter registration and management
+  - name: verify
+    description: Public certificate verification (no auth required)
+  - name: jobs
+    description: Background job status polling
+  - name: audit
+    description: Audit log export
+  - name: health
+    description: Service health check
+
 paths:
+  /api/auth/login:
+    post:
+      operationId: login
+      tags: [auth]
+      summary: Exchange email and password for JWT tokens
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              email: operator@example.com
+              password: supersecret
+      responses:
+        '200':
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: Invalid credentials
+
+  /api/auth/refresh:
+    post:
+      operationId: refreshToken
+      tags: [auth]
+      summary: Rotate refresh token and return a new token pair
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: Token rotated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          description: Invalid or expired refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/auth/logout:
+    post:
+      operationId: logout
+      tags: [auth]
+      summary: Invalidate the current session
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Session invalidated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/readings:
+    get:
+      operationId: listReadings
+      tags: [readings]
+      summary: List meter readings (cursor-based pagination)
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - name: cursor
+          in: query
+          description: ISO timestamp of the last seen row (for pagination)
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Paginated list of readings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadingListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
     post:
       operationId: submitReading
+      tags: [readings]
       summary: Submit a signed meter reading
       description: |
         Verifies the Ed25519 signature, anchors the reading hash on Stellar,
         and mints energy certificates (1 token = 1 kWh).
+
+        Returns `202 Accepted` immediately with `{ reading_id, job_id }`.
+        Poll `GET /api/jobs/{job_id}` for completion status.
+
+        **Replay protection:** include a unique `nonce` per request. Duplicate
+        nonces within 24 hours return the cached response.
+
+        **Timestamp window:** readings older than 5 minutes or more than 1 minute
+        in the future are rejected.
       security: []
       requestBody:
         required: true
@@ -36,6 +191,7 @@ paths:
               kwh: 12.5
               timestamp: 1745366400
               signature_hex: "4b3e9f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f09a"
+              nonce: "unique-nonce-abc123"
       responses:
         '201':
           description: Reading accepted, anchored, and certificates minted
@@ -44,11 +200,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReadingResponse'
         '400':
-          description: Validation failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationError'
+          $ref: '#/components/responses/ValidationError'
         '401':
           description: Ed25519 signature invalid
           content:
@@ -71,6 +223,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded (60 req/min per meter)
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: Rate limit exceeded
         '500':
           description: Anchor or mint failed
           content:
@@ -78,9 +243,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReadingError'
 
+  /api/readings/batch:
+    post:
+      operationId: submitReadingsBatch
+      tags: [readings]
+      summary: Submit up to 100 signed meter readings in one request
+      description: |
+        Each reading is validated, anchored, and minted independently.
+        Returns per-reading status. HTTP 207 Multi-Status when at least one
+        reading succeeded; HTTP 400 when all failed.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReadingRequest'
+              minItems: 1
+              maxItems: 100
+      responses:
+        '207':
+          description: Partial or full success — check per-reading status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchReadingResponse'
+        '400':
+          description: All readings failed or request body invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchReadingResponse'
+
   /api/verify:
     get:
       operationId: verifyCertificate
+      tags: [verify]
       summary: Retrieve chain of custody for a certificate
       description: |
         Public endpoint — no authentication required.
@@ -112,11 +312,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChainOfCustody'
         '400':
-          description: Missing or invalid id parameter
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationError'
+          $ref: '#/components/responses/ValidationError'
         '404':
           description: No certificate matches the given id
           content:
@@ -126,13 +322,100 @@ paths:
               example:
                 error: Certificate not found
 
+  /api/verify/{id}:
+    get:
+      operationId: verifyCertificateById
+      tags: [verify]
+      summary: Retrieve chain of custody by path parameter
+      description: |
+        Identical to `GET /api/verify?id=` but accepts the identifier as a
+        path segment. Useful for REST-style integrations.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Certificate UUID, reading hash (64-char hex), or mint transaction hash
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Certificate found
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            X-Cache:
+              schema:
+                type: string
+                enum: [HIT, MISS]
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainOfCustody'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/certificates:
+    get:
+      operationId: listCertificates
+      tags: [certificates]
+      summary: List certificates (cursor-based pagination)
+      description: |
+        Supports filtering by status, date range, and text search.
+        No authentication required.
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - name: cursor
+          in: query
+          description: ISO timestamp of `issued_at` of the last seen row
+          schema:
+            type: string
+            format: date-time
+        - name: q
+          in: query
+          description: Prefix search on certificate ID or meter ID
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter by retirement status
+          schema:
+            type: string
+            enum: [active, retired]
+        - name: date_from
+          in: query
+          description: Inclusive lower bound on `issued_at` (ISO date)
+          schema:
+            type: string
+            format: date
+        - name: date_to
+          in: query
+          description: Inclusive upper bound on `issued_at` (ISO date)
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Paginated list of certificates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateListResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/certificates/{id}/retire:
     post:
       operationId: retireCertificate
-      summary: Retire a certificate
+      tags: [certificates]
+      summary: Retire a certificate permanently
       description: |
-        Permanently retires a certificate by calling the energy_token contract retire function.
-        A retired certificate cannot be used again.
+        Calls `energy_token.retire` on-chain. A retired certificate cannot be
+        used again. The retirement is recorded on Stellar and in the database.
       security: []
       parameters:
         - name: id
@@ -156,17 +439,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/RetireResponse'
         '400':
-          description: Validation failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationError'
+          $ref: '#/components/responses/ValidationError'
         '404':
-          description: Certificate not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/NotFound'
         '409':
           description: Certificate already retired
           content:
@@ -176,15 +451,156 @@ paths:
               example:
                 error: Certificate already retired
         '500':
-          description: Retire transaction failed
+          $ref: '#/components/responses/InternalError'
+
+  /api/meters:
+    get:
+      operationId: listMeters
+      tags: [meters]
+      summary: List all registered meters
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of meter records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Meter'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      operationId: registerMeter
+      tags: [meters]
+      summary: Register a new meter
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterMeterRequest'
+      responses:
+        '201':
+          description: Meter registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Meter'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: A meter with this public key already exists
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/meters/{id}/revoke:
+    patch:
+      operationId: revokeMeter
+      tags: [meters]
+      summary: Deactivate a meter (set active=false)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Meter deactivated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Meter'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/jobs/{id}:
+    get:
+      operationId: getJob
+      tags: [jobs]
+      summary: Poll background job status
+      description: |
+        Poll this endpoint after `POST /api/readings` to check whether the
+        Stellar anchor and mint have completed.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Job record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/audit-log:
+    get:
+      operationId: exportAuditLog
+      tags: [audit]
+      summary: Export audit log as CSV
+      description: |
+        Returns audit log entries as a CSV file. Defaults to the last 30 days.
+        Requires operator JWT.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: from
+          in: query
+          description: Start of date range (ISO 8601)
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: End of date range (ISO 8601)
+          schema:
+            type: string
+            format: date-time
+        - name: operator_id
+          in: query
+          description: Filter by operator UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: CSV file download
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              example: 'attachment; filename="audit_log_2026-01-01_2026-01-31.csv"'
+          content:
+            text/csv:
+              schema:
+                type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/health:
     get:
       operationId: healthCheck
+      tags: [health]
       summary: Liveness check
       description: Returns 200 when the service is running. Used by uptime monitoring.
       security: []
@@ -205,8 +621,108 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/docs:
+    get:
+      operationId: getOpenApiSpec
+      tags: [health]
+      summary: Serve this OpenAPI specification as YAML
+      security: []
+      responses:
+        '200':
+          description: OpenAPI 3.1 YAML document
+          content:
+            text/yaml:
+              schema:
+                type: string
+
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Supabase JWT obtained from `POST /api/auth/login`
+
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: Maximum number of results to return (max 100)
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid Authorization header
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: Missing Authorization header
+    ValidationError:
+      description: Request body or query parameter validation failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: Not found
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
   schemas:
+    # ── Auth ──────────────────────────────────────────────────────────────────
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+
+    RefreshRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
+          minLength: 1
+
+    TokenResponse:
+      type: object
+      required: [access_token, refresh_token, expires_in, token_type]
+      properties:
+        access_token:
+          type: string
+          description: Short-lived JWT for API requests
+        refresh_token:
+          type: string
+          description: Long-lived token used to obtain a new access token
+        expires_in:
+          type: integer
+          description: Seconds until the access token expires
+        token_type:
+          type: string
+          enum: [Bearer]
+
+    # ── Readings ──────────────────────────────────────────────────────────────
     ReadingRequest:
       type: object
       required: [meter_id, kwh, timestamp, signature_hex]
@@ -221,12 +737,19 @@ components:
           description: Energy generated in kilowatt-hours
         timestamp:
           type: integer
-          description: Unix timestamp in seconds (integer)
+          description: Unix timestamp in seconds (must be within 5 minutes of server time)
         signature_hex:
           type: string
           minLength: 128
           maxLength: 128
-          description: Ed25519 signature of the canonical reading hash, hex-encoded (64 bytes)
+          description: |
+            Ed25519 signature of the canonical reading hash, hex-encoded (64 bytes = 128 hex chars).
+            See `docs/ED25519_PROTOCOL.md` for the signing payload format.
+        nonce:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Unique per-request nonce for replay protection (recommended)
 
     ReadingResponse:
       type: object
@@ -254,6 +777,167 @@ components:
         anchor_tx_hash:
           type: string
           description: Present if anchoring succeeded but minting failed
+        diagnosis:
+          $ref: '#/components/schemas/TracerDiagnosis'
+
+    ReadingListResponse:
+      type: object
+      required: [data, total]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Reading'
+        next_cursor:
+          type: ['string', 'null']
+          format: date-time
+          description: Pass as `cursor` in the next request; null when no more pages
+        total:
+          type: integer
+
+    Reading:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        meter_id:
+          type: string
+          format: uuid
+        kwh:
+          type: number
+        timestamp:
+          type: string
+          format: date-time
+        reading_hash:
+          type: string
+          description: Hex-encoded SHA-256 of the canonical reading payload
+        anchored:
+          type: boolean
+        minted:
+          type: boolean
+        anchor_tx_hash:
+          type: ['string', 'null']
+        mint_tx_hash:
+          type: ['string', 'null']
+
+    BatchReadingResponse:
+      type: object
+      required: [succeeded, failed, results]
+      properties:
+        succeeded:
+          type: integer
+        failed:
+          type: integer
+        results:
+          type: array
+          items:
+            oneOf:
+              - type: object
+                required: [index, status, reading_id, anchor_tx_hash, mint_tx_hash]
+                properties:
+                  index:
+                    type: integer
+                  status:
+                    type: string
+                    enum: [success]
+                  reading_id:
+                    type: string
+                    format: uuid
+                  anchor_tx_hash:
+                    type: string
+                  mint_tx_hash:
+                    type: string
+              - type: object
+                required: [index, status, error, code]
+                properties:
+                  index:
+                    type: integer
+                  status:
+                    type: string
+                    enum: [error]
+                  error:
+                    type: string
+                  code:
+                    type: integer
+
+    TracerDiagnosis:
+      type: object
+      description: Structured diagnosis from tracer-sim when a mint fails
+      properties:
+        error_code:
+          type: string
+        message:
+          type: string
+        suggestion:
+          type: string
+        replayed_at:
+          type: string
+          format: date-time
+
+    # ── Certificates ──────────────────────────────────────────────────────────
+    CertificateListResponse:
+      type: object
+      required: [data, total]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CertificateSummary'
+        next_cursor:
+          type: ['string', 'null']
+          format: date-time
+        total:
+          type: integer
+
+    CertificateSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        kwh:
+          type: number
+        issued_at:
+          type: string
+          format: date-time
+        retired:
+          type: boolean
+        retired_at:
+          type: ['string', 'null']
+          format: date-time
+        retired_by:
+          type: ['string', 'null']
+        mint_tx_hash:
+          type: ['string', 'null']
+        meter_id:
+          type: ['string', 'null']
+          format: uuid
+
+    RetireRequest:
+      type: object
+      required: [wallet_address]
+      properties:
+        wallet_address:
+          type: string
+          description: Stellar G-address of the certificate holder
+
+    RetireResponse:
+      type: object
+      required: [id, retired, retired_at, retired_by, retire_tx_hash]
+      properties:
+        id:
+          type: string
+          format: uuid
+        retired:
+          type: boolean
+        retired_at:
+          type: string
+          format: date-time
+        retired_by:
+          type: string
+        retire_tx_hash:
+          type: string
 
     ChainOfCustody:
       type: object
@@ -293,6 +977,8 @@ components:
             mint_explorer:
               type: string
               format: uri
+            retirement_tx:
+              type: ['string', 'null']
         meter_proof:
           oneOf:
             - type: 'null'
@@ -316,31 +1002,76 @@ components:
                 verified:
                   type: boolean
 
-    RetireRequest:
+    # ── Meters ────────────────────────────────────────────────────────────────
+    RegisterMeterRequest:
       type: object
-      required: [wallet_address]
+      required: [name, cooperative_id, serial_number, pubkey_hex]
       properties:
-        wallet_address:
+        name:
           type: string
-          description: Stellar wallet address of the certificate holder
+          minLength: 1
+          maxLength: 128
+        cooperative_id:
+          type: string
+          format: uuid
+        serial_number:
+          type: string
+          minLength: 1
+          maxLength: 64
+        pubkey_hex:
+          type: string
+          minLength: 64
+          maxLength: 64
+          description: Ed25519 public key, hex-encoded (32 bytes = 64 hex chars)
 
-    RetireResponse:
+    Meter:
       type: object
-      required: [id, retired, retired_at, retired_by, retire_tx_hash]
       properties:
         id:
           type: string
           format: uuid
-        retired:
+        serial_number:
+          type: string
+        pubkey_hex:
+          type: string
+        active:
           type: boolean
-        retired_at:
+        created_at:
           type: string
           format: date-time
-        retired_by:
+        cooperative_id:
           type: string
-        retire_tx_hash:
-          type: string
+          format: uuid
 
+    # ── Jobs ──────────────────────────────────────────────────────────────────
+    Job:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum: [anchor_and_mint]
+        status:
+          type: string
+          enum: [pending, running, done, failed]
+        attempts:
+          type: integer
+        result:
+          type: ['object', 'null']
+          description: Present when status is `done`
+        error:
+          type: ['string', 'null']
+          description: Present when status is `failed`
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ── Health ────────────────────────────────────────────────────────────────
     HealthResponse:
       type: object
       required: [status, ts]
@@ -352,6 +1083,7 @@ components:
           type: integer
           description: Current Unix timestamp in milliseconds
 
+    # ── Errors ────────────────────────────────────────────────────────────────
     Error:
       type: object
       required: [error]


### PR DESCRIPTION
## Summary

Rewrites `openapi.yaml` with a complete OpenAPI 3.1 specification covering every API endpoint, satisfying the acceptance criteria for #307.

## Changes

**New endpoints documented:**
- `POST /api/auth/login`, `POST /api/auth/refresh`, `POST /api/auth/logout`
- `GET /api/readings`, `POST /api/readings`, `POST /api/readings/batch`
- `GET /api/certificates`, `POST /api/certificates/{id}/retire`
- `GET /api/meters`, `POST /api/meters`, `PATCH /api/meters/{id}/revoke`
- `GET /api/verify`, `GET /api/verify/{id}`
- `GET /api/jobs/{id}`
- `GET /api/audit-log`
- `GET /api/health`, `GET /api/docs`

**Spec features:**
- Authentication requirements documented (`bearerAuth` security scheme)
- All error response schemas (400, 401, 404, 409, 429, 500)
- Rate limiting documented on `POST /api/readings`
- Reusable components: `securitySchemes`, `parameters`, `responses`, `schemas`
- Tags for logical grouping

## Tested

Spec is served at `GET /api/docs` (existing route). No functional changes.

Closes #307