### PR TITLE
docs(adr): add ADR-005 monorepo structure and ADR-006 certificate retirement model

### DIFF
--- a/docs/adr/005-monorepo-structure.md
+++ b/docs/adr/005-monorepo-structure.md
@@ -1,0 +1,27 @@
+# ADR-005: Monorepo Structure with Turborepo + pnpm
+
+**Date:** 2026-05-29  
+**Status:** Accepted
+
+## Context
+
+SolarProof spans multiple concerns: Soroban smart contracts (Rust), a Next.js web app (TypeScript), shared Stellar utilities, and simulation scripts. These components share types, constants, and deployment artifacts. Managing them as separate repositories would require manual version synchronisation and make atomic cross-component changes difficult.
+
+## Decision
+
+Adopt a monorepo layout managed by **Turborepo** and **pnpm workspaces**:
+
+```
+solarproof/
+├── apps/contracts/   # Rust / Soroban
+├── apps/web/         # Next.js
+├── packages/stellar/ # Shared TS utilities
+└── scripts/          # Meter simulation
+```
+
+Turborepo handles task orchestration (build, lint, test) with remote caching. pnpm workspaces provide dependency hoisting and cross-package linking.
+
+## Consequences
+
+- **Easier:** atomic commits across contracts + web, shared type definitions, single CI pipeline, unified dependency updates.
+- **Harder:** contributors need both Rust and Node toolchains; Turborepo cache invalidation must be tuned carefully to avoid stale builds.

--- a/docs/adr/006-certificate-retirement-model.md
+++ b/docs/adr/006-certificate-retirement-model.md
@@ -1,0 +1,25 @@
+# ADR-006: Certificate Retirement Model
+
+**Date:** 2026-05-29  
+**Status:** Accepted
+
+## Context
+
+Energy certificates (RECs) must be retired — permanently consumed — to prevent double-counting. The retirement event must be publicly auditable and irreversible. Options considered:
+
+1. **Burn to zero address** — transfer token to `0x000…` (EVM convention, not idiomatic on Stellar).
+2. **Contract-managed burn** — `energy_token` contract exposes a `retire(amount, beneficiary)` function that destroys the balance and emits an on-chain event.
+3. **Off-chain registry** — record retirement in a database only.
+
+## Decision
+
+Use **contract-managed burn** (option 2). The `energy_token` contract's `retire` function:
+
+- Decrements the caller's balance permanently (no re-mint path).
+- Records `(beneficiary, kwh, timestamp, tx_hash)` in the `audit_registry` contract for public verification.
+- Emits a Soroban event consumed by the public verifier UI.
+
+## Consequences
+
+- **Easier:** retirement is cryptographically final and publicly verifiable without trusting SolarProof's database; the verifier at `/verify` can reconstruct the full chain.
+- **Harder:** retired tokens cannot be recovered if a user retires by mistake; UX must include a confirmation step with clear warnings.


### PR DESCRIPTION
## Summary

Adds two missing ADRs to document key architectural decisions.

- **ADR-005**: Monorepo structure — rationale for Turborepo + pnpm workspaces
- **ADR-006**: Certificate retirement model — contract-managed burn via `energy_token.retire()`

Closes #311