### PR TITLE
devops(docker): add health checks for all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,20 @@ services:
     env_file:
       - .env.local
     depends_on:
-      - supabase-db
-      - redis
+      supabase-db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - ./apps/web:/app/apps/web
       - /app/apps/web/node_modules
       - /app/node_modules
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   supabase-db:
     image: supabase/postgres:15.1.0.147
@@ -29,6 +37,12 @@ services:
       POSTGRES_DB: solarproof
     volumes:
       - supabase_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d solarproof"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   redis:
     image: redis:7-alpine
@@ -36,6 +50,12 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   supabase_data:


### PR DESCRIPTION
## Summary

Adds Docker Compose health checks so dependent services wait until dependencies are ready before starting.

| Service | Check | Interval | Retries | Start period |
|---|---|---|---|---|
| `supabase-db` | `pg_isready -U postgres -d solarproof` | 10s | 5 | 20s |
| `redis` | `redis-cli ping` | 10s | 3 | 10s |
| `web` | `wget /api/health` | 30s | 3 | 40s |

`depends_on` updated to use `condition: service_healthy` for deterministic startup order.

Closes #290