### PR TITLE
ci(lint): add Prettier formatting check to CI and pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,15 @@ jobs:
           key: nextjs-${{ runner.os }}-${{ hashFiles('apps/web/**.[jt]s', 'apps/web/**.[jt]sx', 'pnpm-lock.yaml') }}
           restore-keys: nextjs-${{ runner.os }}-
 
-      - name: lint
+      - name: lint (ESLint)
         run: pnpm lint
         working-directory: apps/web
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+      - name: format check (Prettier)
+        run: pnpm prettier --check "**/*.{ts,tsx,md,json}" --ignore-path .gitignore
 
       - name: type-check
         run: pnpm type-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+        name: ESLint
+        language: system
+        entry: bash -c 'cd apps/web && pnpm lint'
+        types: [file]
+        files: \.(ts|tsx|js|jsx)$
+        pass_filenames: false
+
+      - id: prettier
+        name: Prettier
+        language: system
+        entry: pnpm prettier --check
+        types: [file]
+        files: \.(ts|tsx|md|json)$
+
+      - id: cargo-clippy
+        name: Cargo Clippy
+        language: system
+        entry: bash -c 'cd apps/contracts && cargo clippy --all-targets --all-features -- -D warnings'
+        types: [file]
+        files: \.rs$
+        pass_filenames: false
+
+      - id: cargo-fmt
+        name: Cargo fmt
+        language: system
+        entry: bash -c 'cd apps/contracts && cargo fmt --all -- --check'
+        types: [file]
+        files: \.rs$
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Enforces code style in CI and locally via pre-commit hooks.

### CI changes (`.github/workflows/ci.yml`)
- Renamed lint step to `lint (ESLint)` for clarity
- Added `format check (Prettier)` step — runs `prettier --check` on all `ts/tsx/md/json` files
- Both steps block PR merge on failure (existing behaviour preserved)
- `cargo clippy` and `cargo fmt` already present in the `contracts` job

### Pre-commit hooks (`.pre-commit-config.yaml`)
| Hook | Scope |
|---|---|
| ESLint | `ts/tsx/js/jsx` |
| Prettier | `ts/tsx/md/json` |
| cargo clippy | `*.rs` |
| cargo fmt | `*.rs` |

Install locally with: `pip install pre-commit && pre-commit install`

Closes #298