### PR TITLE
docs: add operational runbooks

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,10 @@
+# Runbooks
+
+Operational runbooks for common SolarProof procedures.
+
+| Runbook | Description |
+|---|---|
+| [contract-deployment.md](contract-deployment.md) | Deploy Soroban contracts to testnet and mainnet |
+| [meter-key-rotation.md](meter-key-rotation.md) | Rotate an Ed25519 meter signing key |
+| [failed-mint-investigation.md](failed-mint-investigation.md) | Diagnose and resolve failed energy token mint jobs |
+| [incident-response.md](incident-response.md) | Detect, contain, resolve, and learn from incidents |

--- a/docs/runbooks/contract-deployment.md
+++ b/docs/runbooks/contract-deployment.md
@@ -1,0 +1,89 @@
+# Runbook: Contract Deployment
+
+Covers deploying SolarProof Soroban contracts to testnet and mainnet.
+
+For full deployment documentation see [docs/DEPLOYMENT.md](../DEPLOYMENT.md).
+
+---
+
+## Prerequisites
+
+- Rust toolchain (see `apps/contracts/rust-toolchain.toml`)
+- `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
+- Stellar CLI: `cargo install --locked stellar-cli --features opt`
+- Funded deployer account (testnet: use friendbot; mainnet: real XLM)
+- `DEPLOYER_SECRET_KEY` environment variable set
+
+---
+
+## Testnet Deployment
+
+```bash
+# 1. Build contracts
+cd apps/contracts && stellar contract build
+
+# 2. Deploy (idempotent — skips already-deployed contracts)
+DEPLOYER_SECRET_KEY=<secret> bash scripts/deploy-testnet.sh
+```
+
+The script writes contract IDs to `scripts/deployments/testnet.json`.
+
+```bash
+# 3. Initialize each contract
+ADMIN=$(stellar keys address deployer)
+
+stellar contract invoke --id $TOKEN_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN --minter $ADMIN
+
+stellar contract invoke --id $REGISTRY_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN
+
+stellar contract invoke --id $GOV_ID --source deployer --network testnet \
+  -- initialize --admin $ADMIN --quorum 51 --voting_period_ledgers 17280
+
+# 4. Update docs/deployments.md with the new contract IDs
+# 5. Set contract IDs in .env.local (see docs/DEPLOYMENT.md §2d)
+```
+
+---
+
+## Mainnet Deployment
+
+> ⚠️ Irreversible. Use an HSM-backed key. Test on testnet first.
+
+Same steps as testnet — replace `--network testnet` with `--network mainnet` and use `scripts/deploy-mainnet.sh`.
+
+---
+
+## Verify Deployed Bytecode
+
+```bash
+# Compute local WASM hash
+sha256sum apps/contracts/target/wasm32-unknown-unknown/release/energy_token.wasm
+
+# Compare against on-chain hash at:
+# https://stellar.expert/explorer/testnet/contract/<CONTRACT_ID>
+# Contract tab → WASM section → WASM hash
+```
+
+Hashes must match. A mismatch means the on-chain contract differs from the local build.
+
+---
+
+## Rollback
+
+Soroban contracts are immutable. Rollback = deploy a new contract and update env vars.
+
+1. Deploy corrected WASM → new contract ID
+2. Update `NEXT_PUBLIC_ENERGY_TOKEN_ID` (and/or other IDs) in environment
+3. Redeploy web app (Vercel picks up new env vars automatically)
+4. Update `docs/deployments.md` with new ID and rollback note
+5. Do not delete the old contract — it is an audit record
+
+---
+
+## CI / Automated Deployment
+
+Testnet deployment runs automatically on push to `main` via `.github/workflows/deploy-contracts.yml`.
+
+To trigger manually: GitHub → Actions → Deploy Contracts → Run workflow.

--- a/docs/runbooks/failed-mint-investigation.md
+++ b/docs/runbooks/failed-mint-investigation.md
@@ -1,0 +1,97 @@
+# Runbook: Investigating Failed Mint Jobs
+
+Covers diagnosing and resolving failed energy token mint jobs.
+
+---
+
+## Background
+
+When a meter reading is submitted, the API:
+1. Verifies the Ed25519 signature
+2. Anchors the reading hash to Stellar via `audit_registry`
+3. Mints an `energy_token` (1 token = 1 kWh)
+
+A mint failure means step 3 failed. The reading may still be anchored (step 2 succeeded). Failed mints are recorded in the `mint_jobs` table with a `status` of `failed` and a `diagnosis` field populated by tracer-sim.
+
+---
+
+## Step 1 — Identify the Failed Job
+
+```sql
+SELECT id, meter_id, kwh, created_at, status, diagnosis, anchor_tx_hash, mint_tx_hash
+FROM mint_jobs
+WHERE status = 'failed'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Check the `diagnosis` field — tracer-sim auto-populates a failure reason when available.
+
+---
+
+## Step 2 — Common Failure Causes
+
+| Diagnosis / symptom | Likely cause | Resolution |
+|---|---|---|
+| `insufficient_balance` | Minter account out of XLM | Top up the minter account (see Step 3) |
+| `contract_not_found` | Wrong contract ID in env | Verify `NEXT_PUBLIC_ENERGY_TOKEN_ID` matches deployed contract |
+| `sequence_number_mismatch` | Concurrent mint race | Retry the job (usually self-resolving) |
+| `network_timeout` | Stellar RPC unreachable | Check Stellar network status; retry after recovery |
+| `signature_invalid` | Minter key mismatch | Verify `MINTER_SECRET_KEY` env var matches the contract's authorized minter |
+| `already_minted` | Duplicate job | Check if a successful mint exists for the same `reading_id`; mark job resolved |
+
+---
+
+## Step 3 — Top Up the Minter Account (if needed)
+
+```bash
+# Check minter balance
+stellar account info --account <MINTER_PUBLIC_KEY> --network testnet
+
+# Testnet: use friendbot
+curl "https://friendbot.stellar.org?addr=<MINTER_PUBLIC_KEY>"
+
+# Mainnet: transfer XLM from a funded account
+stellar payment send \
+  --source <FUNDING_SECRET> \
+  --destination <MINTER_PUBLIC_KEY> \
+  --amount 100 \
+  --network mainnet
+```
+
+---
+
+## Step 4 — Retry the Failed Job
+
+```bash
+# Trigger a retry via the API (if a retry endpoint exists)
+curl -X POST https://<api-host>/api/admin/mint-jobs/<job-id>/retry \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Or re-submit the original reading — the server is idempotent for anchoring (returns `409` if already anchored) but will attempt a fresh mint if the previous one failed.
+
+---
+
+## Step 5 — Verify Resolution
+
+```sql
+SELECT id, status, mint_tx_hash FROM mint_jobs WHERE id = '<job-id>';
+```
+
+Confirm `status = 'completed'` and `mint_tx_hash` is populated.
+
+Verify the on-chain mint at:
+```
+https://stellar.expert/explorer/testnet/tx/<mint_tx_hash>
+```
+
+---
+
+## Step 6 — Escalate if Unresolved
+
+If the failure persists after retrying:
+1. Capture the full `diagnosis` text and `anchor_tx_hash`
+2. Open an incident (see [incident-response.md](incident-response.md))
+3. Check Stellar network status at https://status.stellar.org
+4. Review tracer-sim output in application logs for the full replay trace

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,125 @@
+# Runbook: Incident Response
+
+Covers detecting, containing, resolving, and learning from incidents affecting SolarProof.
+
+---
+
+## Severity Levels
+
+| Level | Description | Response time |
+|---|---|---|
+| P1 — Critical | Production down, data loss, security breach | Immediate |
+| P2 — High | Core feature broken, significant user impact | < 1 hour |
+| P3 — Medium | Degraded performance, non-critical feature broken | < 4 hours |
+| P4 — Low | Minor issue, cosmetic, no user impact | Next business day |
+
+---
+
+## Phase 1 — Detection and Triage
+
+1. **Detect** — via monitoring alert, error report, or user feedback
+2. **Record** — open an incident issue on GitHub with:
+   - Severity level
+   - Affected systems (web app, API, database, smart contracts, infrastructure)
+   - Observed symptoms and first detection time
+3. **Assign** — designate an incident commander (IC) responsible for coordination
+4. **Communicate** — notify stakeholders via the agreed channel (Slack, email, etc.)
+
+---
+
+## Phase 2 — Containment
+
+Act to stop the incident from worsening before root cause is known.
+
+| Affected system | Containment action |
+|---|---|
+| Web app / API | Roll back the last Vercel deployment |
+| Smart contract exploit | Invoke contract pause via governance (see below) |
+| Compromised meter key | Deactivate the meter record immediately (see [meter-key-rotation.md](meter-key-rotation.md)) |
+| Database corruption | Stop write traffic; put app in maintenance mode |
+| Failed mints (bulk) | Pause the mint job queue; investigate (see [failed-mint-investigation.md](failed-mint-investigation.md)) |
+
+**Pause a smart contract (if pause function available):**
+
+```bash
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN_KEY> --network mainnet \
+  -- pause
+```
+
+**Roll back a Vercel deployment:**
+
+```bash
+vercel rollback --token <VERCEL_TOKEN>
+# Or via Vercel dashboard: Deployments → previous deployment → Promote to Production
+```
+
+**Preserve evidence before making changes:**
+
+```bash
+# Capture recent application logs
+# Export relevant database tables
+# Screenshot monitoring dashboards
+```
+
+---
+
+## Phase 3 — Investigation
+
+1. Review application logs for errors around the incident start time
+2. Check recent deployments, config changes, and dependency updates
+3. Query the database for anomalous data:
+
+```sql
+-- Recent failed readings
+SELECT * FROM readings WHERE created_at > now() - interval '1 hour' AND status != 'anchored';
+
+-- Recent failed mints
+SELECT * FROM mint_jobs WHERE status = 'failed' AND created_at > now() - interval '1 hour';
+
+-- Audit log for recent admin actions
+SELECT * FROM audit_log ORDER BY created_at DESC LIMIT 50;
+```
+
+4. Check Stellar network status: https://status.stellar.org
+5. Check Vercel deployment status: https://vercel.com/status
+
+---
+
+## Phase 4 — Resolution
+
+1. Apply the fix (code patch, config change, data correction, or rollback)
+2. Validate recovery:
+   - Run smoke tests against production
+   - Confirm error rates return to baseline in monitoring
+   - Verify a successful end-to-end reading submission if the API was affected
+3. Lift containment measures (re-enable features, unpause contracts, restore write traffic)
+4. Confirm with stakeholders that the incident is resolved
+
+---
+
+## Phase 5 — Postmortem
+
+Complete within 48 hours of resolution for P1/P2 incidents.
+
+1. Write a postmortem document covering:
+   - Timeline (detection → containment → resolution)
+   - Root cause
+   - Impact (users affected, data affected, duration)
+   - What went well
+   - What went wrong
+   - Action items with owners and due dates
+2. Update this runbook if any procedure was unclear or missing
+3. Add monitoring or alerting to catch the same issue earlier next time
+4. Share the postmortem with the team
+
+---
+
+## Useful Links
+
+- Stellar network status: https://status.stellar.org
+- Stellar Expert (testnet): https://stellar.expert/explorer/testnet
+- Stellar Expert (mainnet): https://stellar.expert/explorer/mainnet
+- Vercel dashboard: https://vercel.com/dashboard
+- Supabase dashboard: https://app.supabase.com
+- GitHub Actions: https://github.com/AnnabelJoe/solarproof/actions
+- Security policy: [SECURITY.md](../../SECURITY.md)

--- a/docs/runbooks/meter-key-rotation.md
+++ b/docs/runbooks/meter-key-rotation.md
@@ -1,0 +1,77 @@
+# Runbook: Meter Key Rotation
+
+Covers rotating the Ed25519 signing key for a meter device — scheduled rotation, suspected compromise, or key loss.
+
+---
+
+## When to Rotate
+
+- Scheduled rotation (recommended: annually or per security policy)
+- Private key suspected compromised or exposed
+- Device transferred to a new operator
+- Key material lost
+
+---
+
+## Steps
+
+### 1. Generate a new keypair
+
+```bash
+node scripts/gen-meter-key.mjs
+# Writes meter-key-new.json: { private_key_hex, public_key_hex }
+```
+
+For production devices, generate the keypair on the device itself (HSM/TPM). Never generate a production key on a workstation.
+
+### 2. Register the new public key
+
+Insert the new key into the `meters` table with a new UUID, keeping the old record active during the transition:
+
+```sql
+INSERT INTO meters (id, pubkey_hex, cooperative_id, active)
+VALUES (gen_random_uuid(), '<new-64-char-hex-pubkey>', '<cooperative-uuid>', true);
+```
+
+Note the new `meter_id` — the device must use this UUID in all future reading submissions.
+
+### 3. Update the device
+
+Deploy the new private key and new `meter_id` to the device. For HSM-backed devices, provision the new key into the secure enclave and update the device configuration.
+
+### 4. Verify the new key works
+
+Send a test reading using the new key and confirm a `201 Created` response:
+
+```bash
+node scripts/send-reading.mjs \
+  --meter-id <new-meter-uuid> \
+  --kwh 0.001 \
+  --key ./meter-key-new.json \
+  --api https://<your-api-host>
+```
+
+### 5. Deactivate the old meter record
+
+Once the new key is confirmed working, deactivate the old record:
+
+```sql
+UPDATE meters SET active = false WHERE id = '<old-meter-uuid>';
+```
+
+The old record is retained for audit purposes — do not delete it.
+
+### 6. Securely destroy the old private key
+
+- Remove the old key from the device's secure storage
+- Delete any copies from workstations, CI secrets, or backups
+- Record the rotation in the audit log
+
+---
+
+## Notes
+
+- The server rejects readings from inactive meter records (`404` response)
+- Readings signed with the old key after deactivation will be rejected
+- If the key was compromised, deactivate the old record immediately (step 5) before completing the rest of the rotation
+- Test rotation in staging before applying to production meters


### PR DESCRIPTION
## Summary

Adds individual runbooks to `docs/runbooks/` covering the four procedures requested in #315.

## Changes

| File | Contents |
|---|---|
| `docs/runbooks/contract-deployment.md` | Testnet/mainnet deploy steps, bytecode verification, rollback procedure, CI trigger |
| `docs/runbooks/meter-key-rotation.md` | Scheduled and emergency Ed25519 key rotation, deactivation, secure key destruction |
| `docs/runbooks/failed-mint-investigation.md` | Failure cause table, minter top-up, retry steps, escalation path |
| `docs/runbooks/incident-response.md` | Severity levels, triage, containment actions per system, investigation queries, postmortem template |
| `docs/runbooks/README.md` | Index of all runbooks |

## Closes

Closes #315