### PR TITLE
feat: optimize Soroban contract storage (#281)

### DIFF
--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -21,7 +21,7 @@
 //! |-----|-------------|-------|------|
 //! | `DataKey::Admin` | instance | `Address` | ~57 B |
 //! | `DataKey::TotalAnchors` | instance | `u32` | 4 B |
-//! | `DataKey::Anchor(hash)` | persistent | `AuditAnchor` | 36 B |
+//! | `DataKey::Bucket(id)` | persistent | `Map<BytesN<32>, u32>` | Var |
 //!
 //! ## Invariants
 //! 1. Each `reading_hash` can be anchored at most once.
@@ -37,7 +37,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map,
 };
 
 const VERSION: &str = "1.0.0";
@@ -66,9 +66,10 @@ pub enum DataKey {
     Admin,
     /// `Address` — the only address authorised to call `anchor()`.
     ApiSigner,
-    /// `AuditAnchor` — keyed by the 32-byte reading hash.
-    Anchor(BytesN<32>),
-    /// `bool` — keyed by the 32-byte nonce.
+    /// Bucketed storage for reading hashes to reduce ledger entry count.
+    /// `Map<BytesN<32>, u32>` — keyed by bucket index (0-1023).
+    Bucket(u32),
+    /// `bool` — keyed by the 32-byte nonce. Used for idempotency.
     Nonce(BytesN<32>),
     /// `u32` — total number of anchors stored.
     TotalAnchors,
@@ -163,6 +164,13 @@ impl AuditRegistry {
             .expect("not initialized")
     }
 
+    /// Helper to get bucket ID from a hash (0-1023).
+    fn get_bucket_id(hash: &BytesN<32>) -> u32 {
+        let b0 = hash.get(0).unwrap_or(0) as u32;
+        let b1 = hash.get(1).unwrap_or(0) as u32;
+        ((b0 << 8) | b1) % 1024
+    }
+
     /// Anchor a reading hash on-chain.
     ///
     /// # Events
@@ -183,24 +191,28 @@ impl AuditRegistry {
             return Err(Error::Unauthorized);
         }
 
-        let nonce_key = DataKey::Nonce(nonce.clone());
-        if env.storage().persistent().has(&nonce_key) {
+        // Use temporary storage for nonces (idempotency) to reduce persistent entry costs.
+        let nonce_key = DataKey::Nonce(nonce);
+        if env.storage().temporary().has(&nonce_key) {
             return Err(Error::AlreadyAnchored);
         }
 
-        let key = DataKey::Anchor(reading_hash.clone());
-        if env.storage().persistent().has(&key) {
+        let bucket_id = Self::get_bucket_id(&reading_hash);
+        let bucket_key = DataKey::Bucket(bucket_id);
+        let mut bucket: Map<BytesN<32>, u32> = env
+            .storage()
+            .persistent()
+            .get(&bucket_key)
+            .unwrap_or_else(|| Map::new(&env));
+
+        if bucket.contains_key(reading_hash.clone()) {
             return Err(Error::AlreadyAnchored);
         }
 
-        env.storage().persistent().set(&nonce_key, &true);
+        env.storage().temporary().set(&nonce_key, &true);
 
-        let anchor = AuditAnchor {
-            reading_hash: reading_hash.clone(),
-            anchored_at_ledger: env.ledger().sequence(),
-        };
-
-        env.storage().persistent().set(&key, &anchor);
+        bucket.set(reading_hash.clone(), env.ledger().sequence());
+        env.storage().persistent().set(&bucket_key, &bucket);
 
         let count: u32 = env
             .storage()
@@ -224,16 +236,23 @@ impl AuditRegistry {
 
     /// Returns the `AuditAnchor` for `reading_hash`, or `None` if not anchored.
     pub fn verify(env: Env, reading_hash: BytesN<32>) -> Option<AuditAnchor> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Anchor(reading_hash))
+        let bucket_id = Self::get_bucket_id(&reading_hash);
+        let bucket: Map<BytesN<32>, u32> = env.storage().persistent().get(&DataKey::Bucket(bucket_id))?;
+        let anchored_at_ledger = bucket.get(reading_hash.clone())?;
+        Some(AuditAnchor {
+            reading_hash,
+            anchored_at_ledger,
+        })
     }
 
     /// Returns `true` if `reading_hash` has been anchored, `false` otherwise.
     pub fn is_anchored(env: Env, reading_hash: BytesN<32>) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::Anchor(reading_hash))
+        let bucket_id = Self::get_bucket_id(&reading_hash);
+        let bucket: Option<Map<BytesN<32>, u32>> = env.storage().persistent().get(&DataKey::Bucket(bucket_id));
+        match bucket {
+            Some(b) => b.contains_key(reading_hash),
+            None => false,
+        }
     }
 
     /// Returns the total number of reading hashes anchored so far.
@@ -285,7 +304,8 @@ mod tests {
     fn test_anchor_and_verify() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h).unwrap();
+        let n = make_nonce(&env, 1);
+        client.anchor(&api_signer, &h, &n).unwrap();
         assert!(client.is_anchored(&h));
         assert_eq!(client.total_anchors(), 1);
         let anchor = client.verify(&h).unwrap();
@@ -296,7 +316,8 @@ mod tests {
     fn test_anchor_records_ledger_sequence() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h).unwrap();
+        let n = make_nonce(&env, 1);
+        client.anchor(&api_signer, &h, &n).unwrap();
         let anchor = client.verify(&h).unwrap();
         let _ = anchor.anchored_at_ledger;
     }
@@ -305,16 +326,30 @@ mod tests {
     fn test_duplicate_anchor_rejected() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h).unwrap();
-        assert_eq!(client.anchor(&api_signer, &h), Err(Error::AlreadyAnchored));
+        let n1 = make_nonce(&env, 1);
+        let n2 = make_nonce(&env, 2);
+        client.anchor(&api_signer, &h, &n1).unwrap();
+        assert_eq!(client.anchor(&api_signer, &h, &n2), Err(Error::AlreadyAnchored));
+    }
+
+    #[test]
+    fn test_duplicate_nonce_rejected() {
+        let (env, api_signer, client) = setup();
+        let h1 = BytesN::from_array(&env, &[1u8; 32]);
+        let h2 = BytesN::from_array(&env, &[2u8; 32]);
+        let n = make_nonce(&env, 1);
+        client.anchor(&api_signer, &h1, &n).unwrap();
+        assert_eq!(client.anchor(&api_signer, &h2, &n), Err(Error::AlreadyAnchored));
     }
 
     #[test]
     fn test_duplicate_anchor_does_not_increment_total() {
         let (env, api_signer, client) = setup();
         let h = hash(&env);
-        client.anchor(&api_signer, &h).unwrap();
-        let _ = client.anchor(&api_signer, &h);
+        let n1 = make_nonce(&env, 1);
+        let n2 = make_nonce(&env, 2);
+        client.anchor(&api_signer, &h, &n1).unwrap();
+        let _ = client.anchor(&api_signer, &h, &n2);
         assert_eq!(client.total_anchors(), 1);
     }
 
@@ -323,8 +358,8 @@ mod tests {
         let (env, api_signer, client) = setup();
         let h1 = BytesN::from_array(&env, &[0xAAu8; 32]);
         let h2 = BytesN::from_array(&env, &[0xBBu8; 32]);
-        client.anchor(&api_signer, &h1).unwrap();
-        client.anchor(&api_signer, &h2).unwrap();
+        client.anchor(&api_signer, &h1, &make_nonce(&env, 1)).unwrap();
+        client.anchor(&api_signer, &h2, &make_nonce(&env, 2)).unwrap();
         assert!(client.is_anchored(&h1));
         assert!(client.is_anchored(&h2));
         assert_eq!(client.total_anchors(), 2);
@@ -335,7 +370,7 @@ mod tests {
         let (env, _api_signer, client) = setup();
         let attacker = soroban_sdk::Address::generate(&env);
         assert_eq!(
-            client.anchor(&attacker, &hash(&env)),
+            client.anchor(&attacker, &hash(&env), &make_nonce(&env, 1)),
             Err(Error::Unauthorized)
         );
     }
@@ -346,7 +381,7 @@ mod tests {
         let new_signer = soroban_sdk::Address::generate(&env);
         client.set_api_signer(&new_signer);
         assert_eq!(
-            client.anchor(&old_signer, &hash(&env)),
+            client.anchor(&old_signer, &hash(&env), &make_nonce(&env, 1)),
             Err(Error::Unauthorized)
         );
     }
@@ -372,7 +407,7 @@ mod tests {
         let (env, api_signer, client) = setup();
         for i in 0u8..5 {
             client
-                .anchor(&api_signer, &BytesN::from_array(&env, &[i; 32]))
+                .anchor(&api_signer, &BytesN::from_array(&env, &[i; 32]), &make_nonce(&env, i))
                 .unwrap();
         }
         assert_eq!(client.total_anchors(), 5);
@@ -397,7 +432,7 @@ mod tests {
         let count: u8 = 50;
         for i in 0..count {
             let h = BytesN::from_array(&env, &[i; 32]);
-            client.anchor(&api_signer, &h).unwrap();
+            client.anchor(&api_signer, &h, &make_nonce(&env, i)).unwrap();
         }
         assert_eq!(client.total_anchors(), u32::from(count));
         assert!(client.is_anchored(&BytesN::from_array(&env, &[0u8; 32])));
@@ -409,8 +444,8 @@ mod tests {
         let (env, api_signer, client) = setup();
         let all_zeros = BytesN::from_array(&env, &[0x00u8; 32]);
         let all_ones = BytesN::from_array(&env, &[0xFFu8; 32]);
-        client.anchor(&api_signer, &all_zeros).unwrap();
-        client.anchor(&api_signer, &all_ones).unwrap();
+        client.anchor(&api_signer, &all_zeros, &make_nonce(&env, 1)).unwrap();
+        client.anchor(&api_signer, &all_ones, &make_nonce(&env, 2)).unwrap();
         assert!(client.is_anchored(&all_zeros));
         assert!(client.is_anchored(&all_ones));
         assert_eq!(client.total_anchors(), 2);
@@ -431,7 +466,7 @@ mod tests {
         let new_signer = soroban_sdk::Address::generate(&env);
         client.set_api_signer(&new_signer);
         let h = hash(&env);
-        client.anchor(&new_signer, &h).unwrap();
+        client.anchor(&new_signer, &h, &make_nonce(&env, 1)).unwrap();
         assert!(client.is_anchored(&h));
     }
 
@@ -450,5 +485,27 @@ mod tests {
             client.get_version(),
             soroban_sdk::String::from_str(&env, "1.0.0")
         );
+    }
+
+    #[test]
+    fn test_bucket_collision() {
+        let (env, api_signer, client) = setup();
+        // Force hashes that likely end up in the same bucket
+        // Our bucket ID is ((hash[0] << 8) | hash[1]) % 1024
+        // So any hash starting with 0x00 0x00 will be in bucket 0.
+        let mut h1_arr = [0u8; 32];
+        h1_arr[2] = 1;
+        let h1 = BytesN::from_array(&env, &h1_arr);
+        
+        let mut h2_arr = [0u8; 32];
+        h2_arr[2] = 2;
+        let h2 = BytesN::from_array(&env, &h2_arr);
+        
+        client.anchor(&api_signer, &h1, &make_nonce(&env, 1)).unwrap();
+        client.anchor(&api_signer, &h2, &make_nonce(&env, 2)).unwrap();
+        
+        assert!(client.is_anchored(&h1));
+        assert!(client.is_anchored(&h2));
+        assert_eq!(client.total_anchors(), 2);
     }
 }

--- a/apps/contracts/audit_registry/src/lib.rs
+++ b/apps/contracts/audit_registry/src/lib.rs
@@ -488,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bucket_collision() {
+    fn test_issue_281_bucket_collision() {
         let (env, api_signer, client) = setup();
         // Force hashes that likely end up in the same bucket
         // Our bucket ID is ((hash[0] << 8) | hash[1]) % 1024

--- a/docs/contracts/storage_optimization.md
+++ b/docs/contracts/storage_optimization.md
@@ -1,0 +1,40 @@
+# Soroban Contract Storage Optimization Report
+
+## Overview
+The `audit-registry` contract storage has been optimized to reduce ledger entry costs and footprint on the Stellar network.
+
+## Optimization Strategies
+
+### 1. Bucketed Storage
+Previously, each meter reading hash was stored in its own persistent ledger entry. This resulted in one new ledger entry per reading, which is expensive due to the per-entry base cost.
+
+**Optimized Layout:**
+- Readings are now grouped into **1024 buckets**.
+- Each bucket is a single persistent ledger entry containing a `Map<BytesN<32>, u32>` (Reading Hash -> Ledger Sequence).
+- Bucket ID is derived from the first two bytes of the reading hash: `((hash[0] << 8) | hash[1]) % 1024`.
+
+### 2. Redundant Data Removal
+The `AuditAnchor` struct previously stored the `reading_hash` in the entry value. Since the hash is already the key (either in the previous individual entry or in the new bucket Map), it was redundant.
+
+**Optimized Value:**
+- Only the `anchored_at_ledger` (4 bytes) is stored as the value in the bucket Map.
+- The `AuditAnchor` struct is reconstructed on-the-fly when queried.
+
+### 3. Temporary Storage for Idempotency
+Nonces used for transaction idempotency were previously stored in persistent storage.
+
+**Optimized Storage:**
+- Nonces are now stored in **Temporary storage**.
+- This reduces the long-term ledger footprint as nonces only need to be unique for a short window to prevent immediate replays. Permanent replay protection is still provided by the reading hash itself in the bucketed storage.
+
+## Cost Comparison
+
+| Metric | Before Optimization | After Optimization | Improvement |
+|--------|---------------------|--------------------|-------------|
+| **Persistent Entries** | N + M (N readings, M nonces) | min(N, 1024) | ~99.9% reduction for 1M readings |
+| **Temporary Entries** | 0 | M (M nonces) | Better use of cheaper storage |
+| **Data Size (per reading)** | ~70 bytes + entry overhead | ~36 bytes in Map | ~50% reduction in value size |
+| **Base Entry Costs** | 2 per reading | ~0.001 per reading (at scale) | High savings on base fees |
+
+## Documentation
+The contract code in `apps/contracts/audit_registry/src/lib.rs` has been updated with these changes, and all tests have been verified (fixed and extended with bucket collision tests).


### PR DESCRIPTION
This PR optimizes the audit-registry contract storage.

Key Changes:
- Bucketed storage (1024 buckets) to reduce persistent entries.
- Moved nonces to temporary storage.
- Removed redundant reading_hash from storage values.
- Added comprehensive tests for bucket collisions and nonces.

Closes #281