### PR TITLE
feat(web): real-time energy chart with WebSocket + polling fallback

### DIFF
--- a/apps/web/src/components/DashboardChart.tsx
+++ b/apps/web/src/components/DashboardChart.tsx
@@ -1,26 +1,138 @@
 'use client'
 
+import { useEffect, useRef, useState, useCallback } from 'react'
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { Wifi, WifiOff, Radio } from 'lucide-react'
 
-const data = [
-  { day: 'Mon', energy: 14 },
-  { day: 'Tue', energy: 18 },
-  { day: 'Wed', energy: 16 },
-  { day: 'Thu', energy: 22 },
-  { day: 'Fri', energy: 20 },
-  { day: 'Sat', energy: 26 },
-  { day: 'Sun', energy: 24 },
-]
+interface ChartPoint {
+  label: string
+  energy: number
+}
+
+const POLL_INTERVAL_MS = 30_000
+
+async function fetchRecentReadings(): Promise<ChartPoint[]> {
+  try {
+    const res = await fetch('/api/readings?limit=20')
+    if (!res.ok) return []
+    const json = await res.json()
+    const rows: { timestamp: string; kwh: number }[] = json.data ?? []
+    return rows
+      .slice()
+      .reverse()
+      .map((r) => ({
+        label: new Date(r.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        energy: r.kwh,
+      }))
+  } catch {
+    return []
+  }
+}
+
+type ConnectionStatus = 'connecting' | 'live' | 'polling' | 'error'
 
 export function DashboardChart() {
+  const [data, setData] = useState<ChartPoint[]>([])
+  const [status, setStatus] = useState<ConnectionStatus>('connecting')
+  const wsRef = useRef<WebSocket | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const mountedRef = useRef(true)
+
+  const startPolling = useCallback(() => {
+    if (pollRef.current) return
+    setStatus('polling')
+    fetchRecentReadings().then((d) => { if (mountedRef.current && d.length) setData(d) })
+    pollRef.current = setInterval(() => {
+      fetchRecentReadings().then((d) => { if (mountedRef.current && d.length) setData(d) })
+    }, POLL_INTERVAL_MS)
+  }, [])
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+  }, [])
+
+  const appendReading = useCallback((kwh: number, timestamp: string) => {
+    setData((prev) => {
+      const point: ChartPoint = {
+        label: new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        energy: kwh,
+      }
+      const next = [...prev, point]
+      return next.length > 20 ? next.slice(next.length - 20) : next
+    })
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+
+    // Load initial data via REST
+    fetchRecentReadings().then((d) => { if (mountedRef.current && d.length) setData(d) })
+
+    // Attempt WebSocket connection
+    try {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws/readings`)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (!mountedRef.current) return
+        setStatus('live')
+        stopPolling()
+      }
+
+      ws.onmessage = (event) => {
+        if (!mountedRef.current) return
+        try {
+          const reading = JSON.parse(event.data as string)
+          appendReading(reading.kwh, reading.timestamp)
+        } catch { /* ignore malformed messages */ }
+      }
+
+      ws.onerror = () => {
+        if (!mountedRef.current) return
+        setStatus('error')
+        startPolling()
+      }
+
+      ws.onclose = () => {
+        if (!mountedRef.current) return
+        if (status !== 'live') return
+        setStatus('polling')
+        startPolling()
+      }
+    } catch {
+      startPolling()
+    }
+
+    return () => {
+      mountedRef.current = false
+      wsRef.current?.close()
+      wsRef.current = null
+      stopPolling()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const statusConfig: Record<ConnectionStatus, { icon: React.ReactNode; label: string; color: string }> = {
+    connecting: { icon: <Radio className="h-3 w-3 animate-pulse" />, label: 'Connecting…', color: 'text-gray-400' },
+    live:       { icon: <Wifi className="h-3 w-3" />,               label: 'Live',        color: 'text-green-500' },
+    polling:    { icon: <WifiOff className="h-3 w-3" />,            label: 'Polling',     color: 'text-amber-500' },
+    error:      { icon: <WifiOff className="h-3 w-3" />,            label: 'Offline',     color: 'text-red-500' },
+  }
+
+  const { icon, label, color } = statusConfig[status]
+
   return (
     <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-semibold uppercase tracking-[0.24em] text-gray-500">Energy trend</p>
-          <h2 className="mt-2 text-2xl font-semibold text-gray-900">Weekly generation</h2>
+          <h2 className="mt-2 text-2xl font-semibold text-gray-900">Live generation</h2>
         </div>
-        <p className="text-sm text-gray-500">Responsive chart for mobile and desktop</p>
+        <span className={`flex items-center gap-1.5 text-xs font-medium ${color}`} aria-live="polite">
+          {icon}
+          {label}
+        </span>
       </div>
       <div className="h-72 min-h-[18rem] w-full">
         <ResponsiveContainer width="100%" height="100%">
@@ -32,10 +144,10 @@ export function DashboardChart() {
               </linearGradient>
             </defs>
             <CartesianGrid stroke="#e5e7eb" strokeDasharray="3 3" vertical={false} />
-            <XAxis dataKey="day" axisLine={false} tickLine={false} tick={{ fill: '#6b7280' }} />
+            <XAxis dataKey="label" axisLine={false} tickLine={false} tick={{ fill: '#6b7280' }} />
             <YAxis axisLine={false} tickLine={false} tick={{ fill: '#6b7280' }} />
             <Tooltip wrapperStyle={{ borderRadius: 12, border: 'none', boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)' }} />
-            <Area type="monotone" dataKey="energy" stroke="#f59e0b" fill="url(#energyGradient)" strokeWidth={3} />
+            <Area type="monotone" dataKey="energy" stroke="#f59e0b" fill="url(#energyGradient)" strokeWidth={3} isAnimationActive={false} />
           </AreaChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
Replaces static dummy data in `DashboardChart.tsx` with live data from the WebSocket endpoint, with automatic fallback to polling.

## Acceptance criteria

- [x] Chart updates automatically when new meter readings arrive (WebSocket `onmessage`)
- [x] WebSocket connection established on dashboard load
- [x] Graceful fallback to polling (30s interval) if WebSocket unavailable
- [x] Connection status indicator shown to user (Live / Polling / Offline / Connecting)

Closes #260