### PR TITLE
test(web): achieve 80% API route coverage with CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,15 @@ jobs:
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       - run: pnpm test
         working-directory: apps/web
+      - name: Run tests with coverage
+        run: pnpm vitest run --coverage
+        working-directory: apps/web
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: apps/web/coverage/lcov.info
+          flags: web
+          fail_ci_if_error: false
       - run: pnpm build
         working-directory: apps/web
         env:

--- a/apps/web/src/app/api/certificates/route.test.ts
+++ b/apps/web/src/app/api/certificates/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase', () => ({ createServiceClient: vi.fn() }))
+
+import { createServiceClient } from '@/lib/supabase'
+import { GET } from '@/app/api/certificates/route'
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL('http://localhost/api/certificates')
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+  return new NextRequest(url)
+}
+
+const CERT = {
+  id: 'cert-1',
+  kwh: 10,
+  issued_at: '2026-01-01T00:00:00Z',
+  retired: false,
+  retired_at: null,
+  retired_by: null,
+  mint_tx_hash: 'abc',
+  readings: { meter_id: 'meter-1' },
+}
+
+function mockDb(data: unknown[], error: unknown = null, count = 1) {
+  const query: Record<string, unknown> = {}
+  const chain = (obj: Record<string, unknown>) => {
+    ;['select', 'order', 'limit', 'lt', 'eq', 'gte', 'lte', 'or'].forEach((m) => {
+      obj[m] = vi.fn().mockReturnValue(obj)
+    })
+    obj.then = undefined
+    // Make it thenable for await
+    Object.defineProperty(obj, Symbol.iterator, { value: undefined })
+    return obj
+  }
+  const q = chain(query)
+  // Final await resolves with data
+  ;(q as unknown as Promise<unknown>)[Symbol.for('vitest-mock-result')] = { data, error, count }
+  vi.mocked(createServiceClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            lt: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            gte: vi.fn().mockReturnThis(),
+            lte: vi.fn().mockReturnThis(),
+            or: vi.fn().mockResolvedValue({ data, error, count }),
+            then: undefined,
+            // make it awaitable
+            [Symbol.toStringTag]: 'Promise',
+          }),
+        }),
+      }),
+    }),
+  } as ReturnType<typeof createServiceClient>)
+}
+
+function mockDbSimple(data: unknown[], error: unknown = null, count = data.length) {
+  const terminal = vi.fn().mockResolvedValue({ data, error, count })
+  const makeChain = (): Record<string, unknown> => {
+    const obj: Record<string, unknown> = {}
+    ;['lt', 'eq', 'gte', 'lte', 'or'].forEach((m) => { obj[m] = vi.fn().mockReturnValue(obj) })
+    // Make awaitable
+    obj.then = (resolve: (v: unknown) => unknown) => Promise.resolve({ data, error, count }).then(resolve)
+    obj.catch = (reject: (e: unknown) => unknown) => Promise.resolve({ data, error, count }).catch(reject)
+    return obj
+  }
+  vi.mocked(createServiceClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue(makeChain()),
+        }),
+      }),
+    }),
+  } as ReturnType<typeof createServiceClient>)
+  return terminal
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('GET /api/certificates', () => {
+  it('returns 200 with data array on success', async () => {
+    mockDbSimple([CERT])
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body.data)).toBe(true)
+  })
+
+  it('returns 500 when DB errors', async () => {
+    mockDbSimple([], { message: 'db error' })
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('db error')
+  })
+
+  it('respects limit param (max 100)', async () => {
+    mockDbSimple([])
+    const res = await GET(makeRequest({ limit: '200' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns next_cursor when there are more results', async () => {
+    // Return limit+1 items to trigger hasMore
+    const items = Array.from({ length: 21 }, (_, i) => ({ ...CERT, id: `cert-${i}`, issued_at: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`, readings: { meter_id: 'meter-1' } }))
+    mockDbSimple(items, null, 100)
+    const res = await GET(makeRequest({ limit: '20' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.next_cursor).not.toBeNull()
+    expect(body.data).toHaveLength(20)
+  })
+
+  it('returns null next_cursor when no more results', async () => {
+    mockDbSimple([CERT], null, 1)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.next_cursor).toBeNull()
+  })
+
+  it('normalizes readings join to meter_id field', async () => {
+    mockDbSimple([CERT], null, 1)
+    const res = await GET(makeRequest())
+    const body = await res.json()
+    expect(body.data[0].meter_id).toBe('meter-1')
+    expect(body.data[0].readings).toBeUndefined()
+  })
+
+  it('handles array readings join', async () => {
+    const certWithArray = { ...CERT, readings: [{ meter_id: 'meter-arr' }] }
+    mockDbSimple([certWithArray], null, 1)
+    const res = await GET(makeRequest())
+    const body = await res.json()
+    expect(body.data[0].meter_id).toBe('meter-arr')
+  })
+})

--- a/apps/web/src/app/api/meters/route.test.ts
+++ b/apps/web/src/app/api/meters/route.test.ts
@@ -7,7 +7,24 @@ vi.mock('@/lib/auth', () => ({
 }))
 
 import { createServiceClient } from '@/lib/supabase'
-import { POST } from '@/app/api/meters/route'
+import { GET, POST } from '@/app/api/meters/route'
+
+function makeGetRequest() {
+  return {
+    headers: { get: (_: string) => null },
+    nextUrl: { searchParams: new URLSearchParams() },
+  } as unknown as Parameters<typeof GET>[0]
+}
+
+function mockDbGet(data: unknown[], error: unknown = null) {
+  vi.mocked(createServiceClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data, error }),
+      }),
+    }),
+  } as ReturnType<typeof createServiceClient>)
+}
 
 function makeRequest(body: unknown) {
   return {
@@ -67,5 +84,23 @@ describe('POST /api/meters', () => {
     mockDb()
     const res = await POST(makeRequest({ ...VALID_BODY, pubkey_hex: 'short' }))
     expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /api/meters', () => {
+  it('returns 200 with meters list', async () => {
+    mockDbGet([{ id: 'meter-1', serial_number: 'SN-001' }])
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body)).toBe(true)
+  })
+
+  it('returns 500 when DB errors', async () => {
+    mockDbGet([], { message: 'db failure' })
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('db failure')
   })
 })

--- a/apps/web/src/app/api/ready/route.test.ts
+++ b/apps/web/src/app/api/ready/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ createServiceClient: vi.fn() }))
+
+import { createServiceClient } from '@/lib/supabase'
+import { GET } from '@/app/api/ready/route'
+
+function mockDb(error: unknown = null) {
+  vi.mocked(createServiceClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue({ data: [{ id: '1' }], error }),
+      }),
+    }),
+  } as ReturnType<typeof createServiceClient>)
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('GET /api/ready', () => {
+  it('returns 200 when DB is healthy', async () => {
+    mockDb()
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('ok')
+    expect(body.checks.db).toBe(true)
+  })
+
+  it('returns 503 when DB check fails', async () => {
+    mockDb({ message: 'connection refused' })
+    const res = await GET()
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.status).toBe('degraded')
+    expect(body.checks.db).toBe(false)
+  })
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,9 +13,16 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'lcov'],
       all: true,
       include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/test-setup.ts', 'src/**/*.d.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
     },
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache', 'e2e/**'],
   },


### PR DESCRIPTION
Adds missing API route tests and enforces an 80% coverage threshold in CI with Codecov upload.

## Changes

- `certificates/route.test.ts` — new: happy path, DB error, pagination, cursor, field normalization
- `meters/route.test.ts` — added GET tests (list + DB error path)
- `ready/route.test.ts` — new: healthy and degraded states
- `vitest.config.ts` — added `lcov` reporter + 80% thresholds on lines/functions/branches/statements
- `ci.yml` — run `vitest --coverage` and upload `lcov.info` to Codecov

## Acceptance criteria

- [x] Coverage measured with `vitest --coverage`
- [x] All API routes have at least one happy-path test
- [x] Error paths (DB failure, invalid input) tested
- [x] Coverage threshold enforced in CI (minimum 80%)
- [x] Coverage report uploaded to Codecov

Closes #325