### PR TITLE
ci: add dedicated Contracts CI workflow (#287)

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,0 +1,48 @@
+name: Contracts CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "apps/contracts/**"
+      - ".github/workflows/contracts-ci.yml"
+  push:
+    branches: [main, develop]
+    paths:
+      - "apps/contracts/**"
+      - ".github/workflows/contracts-ci.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Rust contracts (fmt + clippy + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.85.0"
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/contracts
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+        working-directory: apps/contracts
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+        working-directory: apps/contracts
+
+      - name: Run tests
+        run: cargo test --all
+        working-directory: apps/contracts


### PR DESCRIPTION
## Summary

Adds a dedicated `contracts-ci.yml` GitHub Actions workflow to run Rust contract tests on every PR.

## Changes

- New workflow `.github/workflows/contracts-ci.yml` scoped to `apps/contracts/**` path changes
- Runs `cargo fmt`, `cargo clippy`, and `cargo test --all` for all three contracts
- Uses `Swatinem/rust-cache@v2` to cache Rust build artifacts
- Workflow blocks PR merge if any step fails

## Acceptance Criteria

- [x] CI workflow runs `cargo test` for all contracts on every PR
- [x] Build cache configured to speed up Rust compilation
- [x] Workflow fails PR merge if any test fails
- [x] Test results reported in PR checks

Closes #287