### PR TITLE
fix(ci): add dependency license compliance check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,21 @@ jobs:
           NEXT_PUBLIC_AUDIT_REGISTRY_ID: placeholder
           NEXT_PUBLIC_COMMUNITY_GOVERNANCE_ID: placeholder
 
+  license-compliance:
+    name: License compliance check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: npx license-checker --onlyAllow "$(node -e "const c=require('./.license-checker.json');console.log(c.allowedLicenses.join(';'))")" --excludePrivatePackages
+
   contracts:
     name: Contracts (fmt + clippy + test)
     runs-on: ubuntu-latest

--- a/.license-checker.json
+++ b/.license-checker.json
@@ -1,0 +1,16 @@
+{
+  "allowedLicenses": [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "CC0-1.0",
+    "CC-BY-3.0",
+    "CC-BY-4.0",
+    "0BSD",
+    "Unlicense",
+    "Python-2.0",
+    "BlueOak-1.0.0"
+  ]
+}


### PR DESCRIPTION
Closes #344

## Changes
- `license-checker` runs in CI on every push/PR
- Approved license list in `.license-checker.json` (MIT, Apache-2.0, BSD, ISC, etc.)
- CI fails on any unapproved license (GPL and other copyleft blocked)