### PR TITLE
feat: add public v1 verify API and OpenAPI spec (#352)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -358,6 +358,82 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/verify/{certificateId}:
+    get:
+      operationId: verifyCertificateV1
+      tags: [verify]
+      summary: Public certificate verification (v1)
+      description: |
+        Returns the full chain of custody for a certificate. No authentication required.
+
+        Accepts a certificate UUID, reading hash (64-char hex), or mint transaction hash
+        as the `certificateId` path parameter.
+
+        Results are cached for 60 seconds. Rate limited to 60 requests per minute per IP.
+      security: []
+      parameters:
+        - name: certificateId
+          in: path
+          required: true
+          description: Certificate UUID, reading hash (64-char hex), or mint transaction hash
+          schema:
+            type: string
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+      responses:
+        '200':
+          description: Full chain of custody
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              example: public, max-age=60, stale-while-revalidate=30
+            X-Cache:
+              schema:
+                type: string
+                enum: [HIT, MISS]
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainOfCustody'
+              example:
+                certificate:
+                  id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                  kwh: 12.5
+                  issued_at: '2026-01-15T10:30:00Z'
+                  retired: false
+                  retired_at: null
+                  retired_by: null
+                on_chain:
+                  anchor_tx: abc123def456
+                  anchor_explorer: https://stellar.expert/explorer/testnet/tx/abc123def456
+                  mint_tx: def456abc123
+                  mint_explorer: https://stellar.expert/explorer/testnet/tx/def456abc123
+                  retirement_tx: null
+                meter_proof:
+                  meter_id: meter-001
+                  reading_hash: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+                  signature_hex: aabbccdd...
+                  kwh: 12.5
+                  timestamp: '2026-01-15T10:00:00Z'
+                  verified: true
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: Too Many Requests
+
   /api/certificates:
     get:
       operationId: listCertificates


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/verify/:certificateId` as a public, unauthenticated endpoint for third-party certificate verification, and documents it in the OpenAPI spec.

## Changes

- `apps/web/src/app/api/v1/verify/[id]/route.ts` — re-exports from the existing `/api/verify/[id]` handler (no auth required)
- `openapi.yaml` — adds `/api/v1/verify/{certificateId}` path with full schema, example response, and 429 rate-limit response

## Acceptance Criteria

- [x] `GET /api/v1/verify/:certificateId` returns full chain of custody
- [x] No authentication required
- [x] Response includes: meter ID, reading, signature, anchor tx, certificate, retirement status
- [x] Rate limited to prevent abuse (60 req/min via middleware)
- [x] Documented in OpenAPI spec

## Type of change
- [x] New feature

## Related issue
Closes #352

## Checklist
- [x] Tests pass
- [x] No new lint warnings
- [x] Docs updated if needed
- [x] PR targets `develop`