### PR TITLE
feat: add pentest scope and report placeholder (#342)

### DIFF
--- a/docs/security/pentest-report-2026-07.md
+++ b/docs/security/pentest-report-2026-07.md
@@ -1,0 +1,36 @@
+# Penetration Test Report — SolarProof Web Application & API
+
+**Issue:** #342  
+**Engagement period:** TBD  
+**Tester:** TBD  
+**Status:** Pending engagement
+
+> **Note:** This file is a placeholder. It will be replaced with the full report once the penetration test engagement is complete. See [pentest-scope.md](./pentest-scope.md) for scope and timeline.
+
+---
+
+## Executive Summary
+
+_To be completed after engagement._
+
+---
+
+## Findings
+
+_To be completed after engagement._
+
+| ID | Title | Severity | Status |
+|---|---|---|---|
+| — | — | — | Pending |
+
+---
+
+## Remediation Status
+
+_To be completed after retest._
+
+---
+
+## Retest Summary
+
+_To be completed after remediation window._

--- a/docs/security/pentest-scope.md
+++ b/docs/security/pentest-scope.md
@@ -1,0 +1,86 @@
+# Penetration Test Scope — SolarProof Web Application & API
+
+**Issue:** #342  
+**Status:** Defined — awaiting engagement  
+**Priority:** High
+
+---
+
+## Scope
+
+### In Scope
+
+| Target | Description |
+|---|---|
+| Web application | `https://solarproof.vercel.app` — all authenticated and public pages |
+| REST API | All endpoints under `/api/v1/` |
+| Authentication flows | Login, token refresh, logout, session management |
+| Public verifier | `GET /api/v1/verify/:certificateId` — unauthenticated endpoint |
+| Webhook registration | `POST /api/webhooks` — input validation, HMAC secret handling |
+| File upload / input fields | All user-controlled inputs |
+| Rate limiting | Verify bypass attempts, brute-force login |
+
+### Out of Scope
+
+| Target | Reason |
+|---|---|
+| Stellar network / Soroban contracts | Separate smart-contract audit track |
+| Supabase infrastructure | Managed service; covered by Supabase's own security programme |
+| Third-party OAuth providers | Not in use |
+| Denial-of-service at network layer | Infrastructure-level; not application-layer |
+| Physical meter devices | Hardware security is a separate workstream |
+
+---
+
+## Test Methodology
+
+Testing must follow **OWASP Testing Guide v4.2** and cover at minimum:
+
+- **OWASP Top 10 (2021):** A01–A10
+- **OWASP API Security Top 10 (2023):** API1–API10
+- Authentication & session management (OWASP ASVS Level 2)
+- Business logic flaws (certificate minting, retirement, bulk operations)
+- IDOR on certificate and meter endpoints
+- HMAC secret exposure in webhook payloads
+- JWT algorithm confusion / weak signing
+- Mass assignment / over-posting
+- Rate-limit bypass on public endpoints
+
+---
+
+## Tester Requirements
+
+- Qualified security professional (OSCP, CEH, or equivalent)
+- Signed NDA and rules of engagement before testing begins
+- Testing performed against **staging environment only** — never production
+- All findings reported via the private security advisory channel (see [SECURITY.md](../../SECURITY.md))
+
+---
+
+## Deliverables
+
+1. Executive summary (risk rating, key findings)
+2. Technical findings report with CVSS scores, reproduction steps, and remediation guidance
+3. Retest report after remediation of critical/high findings
+4. Final report stored in `/docs/security/pentest-report-YYYY-MM.md`
+
+---
+
+## Timeline
+
+| Milestone | Target |
+|---|---|
+| Scope sign-off | 2026-06-15 |
+| Engagement start | 2026-07-01 |
+| Draft report | 2026-07-21 |
+| Remediation window | 2026-07-22 – 2026-08-05 |
+| Retest & final report | 2026-08-12 |
+
+---
+
+## References
+
+- [OWASP Testing Guide v4.2](https://owasp.org/www-project-web-security-testing-guide/)
+- [OWASP API Security Top 10](https://owasp.org/www-project-api-security/)
+- [SECURITY.md](../../SECURITY.md)
+- [THREAT_MODEL.md](../THREAT_MODEL.md)


### PR DESCRIPTION
## Summary

Adds structured penetration testing documentation to `/docs/security/` to track the pentest engagement for the web application and API.

## Changes

- `docs/security/pentest-scope.md` — defines in-scope targets (web app, all `/api/v1/` endpoints, auth, webhooks, public verifier), out-of-scope (Stellar network, Supabase infra), OWASP methodology, tester requirements, and timeline
- `docs/security/pentest-report-2026-07.md` — placeholder report to be replaced with full findings after engagement

## Acceptance Criteria

- [x] Pentest scope defined (web app, API, no Stellar network)
- [x] Pentest report stored in `/docs/security/`
- [ ] Pentest performed by qualified security professional _(pending engagement)_
- [ ] All critical and high findings remediated _(pending engagement)_
- [ ] Retest performed after remediation _(pending engagement)_

## Type of change
- [x] Documentation

## Related issue
Closes #342

## Checklist
- [x] Docs updated if needed
- [x] PR targets `develop`