### PR TITLE
feat: add bulk certificate retirement API and UI (#347)

### DIFF
--- a/apps/web/src/app/api/certificates/retire/bulk/route.ts
+++ b/apps/web/src/app/api/certificates/retire/bulk/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createServiceClient } from '@/lib/supabase'
+import { retireCertificate } from '@/lib/stellar'
+import { fireWebhook } from '@/lib/webhooks'
+
+const MAX_BULK = 100
+
+const BulkRetireSchema = z.object({
+  certificate_ids: z.array(z.string().uuid()).min(1).max(MAX_BULK),
+  wallet_address: z.string().min(1),
+})
+
+/**
+ * POST /api/certificates/retire/bulk
+ *
+ * Retire up to 100 certificates in a single request.
+ * Returns per-certificate success/failure status.
+ * Partial failures are reported — the operation is best-effort, not atomic.
+ *
+ * Body: { certificate_ids: string[], wallet_address: string }
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null)
+  const parsed = BulkRetireSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { certificate_ids, wallet_address } = parsed.data
+  const db = createServiceClient()
+
+  const { data: certs, error: fetchErr } = await db
+    .from('certificates')
+    .select('*')
+    .in('id', certificate_ids)
+
+  if (fetchErr) {
+    return NextResponse.json({ error: 'Failed to fetch certificates' }, { status: 500 })
+  }
+
+  const certMap = new Map((certs ?? []).map((c) => [c.id, c]))
+
+  const results = await Promise.all(
+    certificate_ids.map(async (id) => {
+      const cert = certMap.get(id)
+      if (!cert) return { id, success: false, error: 'Certificate not found' }
+      if (cert.retired) return { id, success: false, error: 'Already retired' }
+
+      try {
+        const retireTxHash = await retireCertificate(wallet_address, cert.kwh)
+
+        const { data: updated, error: updateErr } = await db
+          .from('certificates')
+          .update({
+            retired: true,
+            retired_at: new Date().toISOString(),
+            retired_by: wallet_address,
+          })
+          .eq('id', id)
+          .select()
+          .single()
+
+        if (updateErr || !updated) {
+          return { id, success: false, error: 'Failed to update certificate' }
+        }
+
+        void fireWebhook(updated.cooperative_id, 'retire', {
+          certificate_id: updated.id,
+          retired_by: updated.retired_by,
+          retire_tx_hash: retireTxHash,
+        })
+
+        return { id, success: true, retire_tx_hash: retireTxHash }
+      } catch (err) {
+        return { id, success: false, error: err instanceof Error ? err.message : 'Retire failed' }
+      }
+    })
+  )
+
+  const succeeded = results.filter((r) => r.success).length
+  const failed = results.length - succeeded
+
+  return NextResponse.json(
+    { results, summary: { total: results.length, succeeded, failed } },
+    { status: failed === results.length ? 500 : 200 }
+  )
+}

--- a/apps/web/src/app/certificates/page.tsx
+++ b/apps/web/src/app/certificates/page.tsx
@@ -9,6 +9,8 @@ import { useToast } from '@/components/toast'
 import { useWallet } from '@/hooks/useWallet'
 import { WalletGate } from '@/components/wallet-gate'
 
+const MAX_BULK = 100
+
 interface Certificate {
   id: string
   kwh: number
@@ -40,6 +42,8 @@ export default function CertificatesPage() {
   const { toast, dismiss } = useToast()
   const { address, connected } = useWallet()
   const [retiring, setRetiring] = useState<Certificate | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [bulkRetiring, setBulkRetiring] = useState(false)
 
   // Read filter state from URL
   const q = searchParams.get('q') ?? ''
@@ -110,6 +114,53 @@ export default function CertificatesPage() {
     } catch (err) {
       dismiss(pendingId)
       toast('error', err instanceof Error ? err.message : 'Retirement failed')
+    }
+  }
+
+  const activeData = data.filter((c) => !c.retired)
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    const activeIds = activeData.map((c) => c.id)
+    const allSelected = activeIds.every((id) => selected.has(id))
+    setSelected(allSelected ? new Set() : new Set(activeIds.slice(0, MAX_BULK)))
+  }
+
+  async function handleBulkRetire() {
+    if (!selected.size || !address) return
+    setBulkRetiring(true)
+    const pendingId = toast('pending', `Retiring ${selected.size} certificate(s)…`)
+    try {
+      const res = await fetch('/api/certificates/retire/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ certificate_ids: [...selected], wallet_address: address }),
+      })
+      dismiss(pendingId)
+      const json = await res.json().catch(() => ({}))
+      const { summary } = json
+      if (summary) {
+        toast(
+          summary.failed === 0 ? 'success' : 'error',
+          `${summary.succeeded} retired, ${summary.failed} failed`
+        )
+      } else {
+        toast('error', 'Bulk retirement failed')
+      }
+      setSelected(new Set())
+      qc.invalidateQueries({ queryKey: ['certificates'] })
+    } catch (err) {
+      dismiss(pendingId)
+      toast('error', err instanceof Error ? err.message : 'Bulk retirement failed')
+    } finally {
+      setBulkRetiring(false)
     }
   }
 
@@ -205,6 +256,29 @@ export default function CertificatesPage() {
           )}
         </div>
 
+        {/* Bulk retire bar */}
+        {selected.size > 0 && (
+          <div className="mb-3 flex items-center gap-3 rounded-lg border border-yellow-300 bg-yellow-50 px-4 py-2 dark:border-yellow-700 dark:bg-yellow-900/20">
+            <span className="text-sm text-yellow-800 dark:text-yellow-300">
+              {selected.size} certificate{selected.size !== 1 ? 's' : ''} selected
+            </span>
+            <button
+              onClick={handleBulkRetire}
+              disabled={bulkRetiring || !connected}
+              className="ml-auto rounded-md bg-green-600 px-3 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {bulkRetiring ? 'Retiring…' : 'Retire selected'}
+            </button>
+            <button
+              onClick={() => setSelected(new Set())}
+              className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400"
+              aria-label="Clear selection"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+
         {error && (
           <p role="alert" className="mb-4 text-sm text-red-600 dark:text-red-400">
             Failed to load certificates.
@@ -220,6 +294,15 @@ export default function CertificatesPage() {
             >
               <thead>
                 <tr className="bg-gray-50 dark:bg-gray-800/50">
+                  <th scope="col" className="px-4 py-3">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all active certificates"
+                      checked={activeData.length > 0 && activeData.every((c) => selected.has(c.id))}
+                      onChange={toggleSelectAll}
+                      className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                    />
+                  </th>
                   {['Certificate ID', 'Meter ID', 'kWh', 'Issued', 'Status', 'Action'].map((h) => (
                     <th
                       key={h}
@@ -234,13 +317,24 @@ export default function CertificatesPage() {
               <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
                 {isLoading ? (
                   <tr>
-                    <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-400">
+                    <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">
                       Loading…
                     </td>
                   </tr>
                 ) : data.length > 0 ? (
                   data.map((cert) => (
                     <tr key={cert.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/40">
+                      <td className="px-4 py-3">
+                        {!cert.retired && (
+                          <input
+                            type="checkbox"
+                            aria-label={`Select certificate ${cert.id.slice(0, 8)}`}
+                            checked={selected.has(cert.id)}
+                            onChange={() => toggleSelect(cert.id)}
+                            className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                          />
+                        )}
+                      </td>
                       <td className="px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
                         {cert.id.slice(0, 8)}…
                       </td>
@@ -280,7 +374,7 @@ export default function CertificatesPage() {
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                    <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
                       No certificates found.
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

Adds `POST /api/certificates/retire/bulk` for portfolio managers to retire up to 100 certificates in a single request, and updates the certificates UI with multi-select checkboxes and a bulk retire action bar.

## Changes

- `apps/web/src/app/api/certificates/retire/bulk/route.ts` — new bulk retirement endpoint
- `apps/web/src/app/certificates/page.tsx` — checkbox column, select-all, bulk retire bar

## Acceptance Criteria

- [x] `POST /api/certificates/retire/bulk` accepts array of certificate IDs
- [x] Processes up to 100 certificates per request
- [x] Returns per-certificate success/failure status
- [x] UI allows selecting multiple certificates and retiring in bulk
- [x] Bulk operation provides clear partial failure handling (best-effort, not atomic)

## Type of change
- [x] New feature

## Related issue
Closes #347

## Checklist
- [x] Tests pass
- [x] No new lint warnings
- [x] PR targets `develop`