### PR TITLE
feat: GET/DELETE /api/meters/:id with admin auth (#269)

### DIFF
--- a/apps/web/src/app/api/meters/[id]/route.test.ts
+++ b/apps/web/src/app/api/meters/[id]/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ createServiceClient: vi.fn() }))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ user: { id: 'user-1' }, accessToken: 'tok' }),
+  isAuthError: vi.fn().mockReturnValue(false),
+}))
+
+import { createServiceClient } from '@/lib/supabase'
+import { GET, DELETE } from '@/app/api/meters/[id]/route'
+
+const METER = { id: 'meter-1', serial_number: 'SN-001', pubkey_hex: 'a'.repeat(64), active: true, created_at: '2024-01-01T00:00:00Z', cooperative_id: 'coop-1' }
+
+function makeRequest() {
+  return { headers: { get: (_: string) => null } } as unknown as Parameters<typeof GET>[0]
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function mockDb({ found = true, updatedActive = false } = {}) {
+  const single = vi.fn().mockResolvedValue(
+    found
+      ? { data: updatedActive ? { id: METER.id, active: false } : METER, error: null }
+      : { data: null, error: { message: 'not found' } }
+  )
+  vi.mocked(createServiceClient).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single,
+    }),
+  } as unknown as ReturnType<typeof createServiceClient>)
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('GET /api/meters/:id', () => {
+  it('returns 200 with meter when found', async () => {
+    mockDb()
+    const res = await GET(makeRequest(), makeParams('meter-1'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.id).toBe('meter-1')
+  })
+
+  it('returns 404 when meter not found', async () => {
+    mockDb({ found: false })
+    const res = await GET(makeRequest(), makeParams('missing'))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/meters/:id', () => {
+  it('returns 200 with active=false when meter deactivated', async () => {
+    mockDb({ updatedActive: true })
+    const res = await DELETE(makeRequest(), makeParams('meter-1'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.active).toBe(false)
+  })
+
+  it('returns 404 when meter not found', async () => {
+    mockDb({ found: false })
+    const res = await DELETE(makeRequest(), makeParams('missing'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/web/src/app/api/meters/[id]/route.ts
+++ b/apps/web/src/app/api/meters/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase'
+import { requireAuth, isAuthError } from '@/lib/auth'
+
+type Params = { params: Promise<{ id: string }> }
+
+/**
+ * GET /api/meters/:id — retrieve a single meter (requires operator JWT).
+ */
+export async function GET(req: NextRequest, { params }: Params) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
+  const { id } = await params
+  const db = createServiceClient()
+
+  const { data, error } = await db
+    .from('meters')
+    .select('id, serial_number, pubkey_hex, active, created_at, cooperative_id')
+    .eq('id', id)
+    .single()
+
+  if (error || !data) return NextResponse.json({ error: 'Meter not found' }, { status: 404 })
+  return NextResponse.json(data)
+}
+
+/**
+ * DELETE /api/meters/:id — deactivate a meter (requires operator JWT).
+ *
+ * Soft-deletes by setting active=false rather than removing the row so
+ * historical readings remain linked.
+ */
+export async function DELETE(req: NextRequest, { params }: Params) {
+  const auth = await requireAuth(req)
+  if (isAuthError(auth)) return auth
+
+  const { id } = await params
+  const db = createServiceClient()
+
+  const { data, error } = await db
+    .from('meters')
+    .update({ active: false })
+    .eq('id', id)
+    .select('id, active')
+    .single()
+
+  if (error || !data) return NextResponse.json({ error: 'Meter not found' }, { status: 404 })
+  return NextResponse.json(data)
+}

--- a/apps/web/src/app/api/v1/meters/[id]/route.ts
+++ b/apps/web/src/app/api/v1/meters/[id]/route.ts
@@ -1,0 +1,1 @@
+export { GET, DELETE } from '@/app/api/meters/[id]/route'


### PR DESCRIPTION
## Summary

Closes #269

Adds the missing `GET` and `DELETE` endpoints for individual meter management, completing the meter device registration API.

## Changes

- `api/meters/[id]/route.ts` — GET retrieves meter info (404 if missing); DELETE soft-deactivates (active=false), keeping historical readings intact
- Both endpoints require operator JWT via `requireAuth()`
- `api/v1/meters/[id]/route.ts` — v1 re-export
- `route.test.ts` — 4 unit tests covering 200/404 for both operations

## Acceptance criteria
- [x] POST /api/meters — register meter with public key (existing)
- [x] GET /api/meters/:id — retrieve meter info
- [x] DELETE /api/meters/:id — deactivate a meter
- [x] Admin authentication required for all endpoints
- [x] Public key stored and validated on registration